### PR TITLE
Add an example of customizing deployment zones

### DIFF
--- a/examples/multi_region_customize/.gitignore
+++ b/examples/multi_region_customize/.gitignore
@@ -1,0 +1,3 @@
+.terraform*
+terraform.d
+terraform.tfstate*

--- a/examples/multi_region_customize/README.md
+++ b/examples/multi_region_customize/README.md
@@ -1,5 +1,12 @@
 ## Inputs
 
+Demonstrates how you deploy resources to a different deployment region to the one
+implicit in the API URL used to create the consortium.
+
+Provides a starting point for creating multi-region blockchain environments on Kaleido.
+
+> Note the API URL determines where the metadata for your business network is located, so should be chosen with care.
+
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | env_types | List of environment types you want to deploy. Options are 'quorum' and 'geth'. | list | `<list>` | no |

--- a/examples/multi_region_customize/README.md
+++ b/examples/multi_region_customize/README.md
@@ -1,0 +1,11 @@
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| env_types | List of environment types you want to deploy. Options are 'quorum' and 'geth'. | list | `<list>` | no |
+| kaleido_api_key | Kaleido API Key | string | - | yes |
+| kaleido_api_url | API RUL https://docs.kaleido.io/developers/automation/regions/ for regional URLs (defines metadata location) | string | `` | no |
+| cloud | `aws` or `azure` | string | `` | no |
+| region | `us-east-2`, `westus2`, `ap-southeast-2` etc. | string | `` | no |
+| quorum_consensus | Consensus methods supported by quorum. | list | `<list>` | no |
+

--- a/examples/multi_region_customize/README.md
+++ b/examples/multi_region_customize/README.md
@@ -11,8 +11,7 @@ Provides a starting point for creating multi-region blockchain environments on K
 |------|-------------|:----:|:-----:|:-----:|
 | env_types | List of environment types you want to deploy. Options are 'quorum' and 'geth'. | list | `<list>` | no |
 | kaleido_api_key | Kaleido API Key | string | - | yes |
-| kaleido_api_url | API RUL https://docs.kaleido.io/developers/automation/regions/ for regional URLs (defines metadata location) | string | `` | no |
+| kaleido_api_url | API URL https://docs.kaleido.io/developers/automation/regions/ for regional URLs (defines metadata location) | string | `` | no |
 | cloud | `aws` or `azure` | string | `` | no |
 | region | `us-east-2`, `westus2`, `ap-southeast-2` etc. | string | `` | no |
 | quorum_consensus | Consensus methods supported by quorum. | list | `<list>` | no |
-

--- a/examples/multi_region_customize/main.tf
+++ b/examples/multi_region_customize/main.tf
@@ -28,6 +28,8 @@ resource "kaleido_membership" "member" {
 
 /*
 This whitelists a region into the consortium for deployment
+This is only required if deploying to a zone that is not the home zone
+of the API URL - otherwise you will get a 409 conflict on deployment
 */
 resource "kaleido_czone" "allowed_region" {
   consortium_id = "${kaleido_consortium.consortium.id}"
@@ -40,7 +42,7 @@ Create an environment
 */
 resource "kaleido_environment" "env" {
   consortium_id = "${kaleido_consortium.consortium.id}"
-  multi_region = "${var.multi_region}"
+  multi_region = true
   name = "${var.env_name}"
   env_type = "${var.provider}"
   consensus_type = "${var.consensus}"

--- a/examples/multi_region_customize/main.tf
+++ b/examples/multi_region_customize/main.tf
@@ -1,0 +1,73 @@
+/*
+This creates suite of environments using all available
+environment types and consensus methods.
+*/
+
+provider "kaleido" {
+  "api" = "${var.kaleido_api_url}"
+  "api_key" = "${var.kaleido_api_key}"
+}
+
+/*
+This represents a Consortia. Give it a name and a description.
+"mode" can be set to "single-org" or ...
+*/
+resource "kaleido_consortium" "consortium" {
+  name = "${var.consortium_name}"
+  description = "${var.network_description}"
+}
+
+/*
+This creates a membership for each node
+*/
+resource "kaleido_membership" "member" {
+  count = "${var.node_count}"
+  consortium_id = "${kaleido_consortium.consortium.id}"
+  org_name = "Org ${count.index + 1}"
+}
+
+/*
+This whitelists a region into the consortium for deployment
+*/
+resource "kaleido_czone" "allowed_region" {
+  consortium_id = "${kaleido_consortium.consortium.id}"
+  cloud = "${var.cloud}"
+  region = "${var.region}"
+}
+
+/*
+Create an environment
+*/
+resource "kaleido_environment" "env" {
+  consortium_id = "${kaleido_consortium.consortium.id}"
+  multi_region = "${var.multi_region}"
+  name = "${var.env_name}"
+  env_type = "${var.provider}"
+  consensus_type = "${var.consensus}"
+  description = "${var.env_description}"
+}
+
+/*
+This creates the first deployment zone for your environment.
+For this sample we refer to it explicitly when deploying nodes, showing how
+you could have multiple deployment zones in a single environment if required
+*/
+resource "kaleido_ezone" "deployment_zone" {
+  consortium_id = "${kaleido_consortium.consortium.id}"
+  environment_id = "${kaleido_environment.env.id}"
+  cloud = "${var.cloud}"
+  region = "${var.region}"
+}
+
+/*
+Create nodes
+*/
+resource "kaleido_node" "kaleido" {
+  count = "${var.node_count}"
+  consortium_id = "${kaleido_consortium.consortium.id}"
+  environment_id = "${kaleido_environment.env.id}"
+  membership_id = "${element(kaleido_membership.member.*.id, count.index)}"
+  zone_id = "${kaleido_ezone.deployment_zone.id}"
+  name = "Node ${count.index + 1}"
+  size = "${var.node_size}"
+}

--- a/examples/multi_region_customize/variables.tf
+++ b/examples/multi_region_customize/variables.tf
@@ -1,0 +1,71 @@
+variable "kaleido_api_key" {
+  type = "string"
+  description = "Kaleido API Key"
+}
+
+variable "kaleido_api_url" {
+  type = "string"
+  description = "The regional API URL you use will determine the region your metadata is located in"
+  default = "https://console-us1.kaleido.io/api/v1"
+}
+
+variable "cloud" {
+  type = "string"
+  description = "The deployment cloud for your environment - sample deploys all nodes to a single cloud"
+  default = "azure"
+}
+
+variable "region" {
+  type = "string"
+  description = "The deployment region for your environment - sample deploys all nodes to a single region"
+  default = "westus2"
+}
+
+variable "provider" {
+  type = "string"
+  default = "quorum"
+  description = "Protocol implementation to deploy."
+}
+
+variable "consensus" {
+  type = "string"
+  default = "ibft"
+  description = "Consensus mechanism."
+}
+
+variable "multi_region" {
+  type = "string"
+  default = false
+  description = "Make the environment multi-region compatible to support additional regions, now or in the future"
+}
+
+variable "node_size" {
+  type = "string"
+  default = "small"
+  description = "Size of the node"
+}
+
+variable "node_count" {
+  type = "string"
+  default = 4
+  description = "Count of nodes to create - each will have its own membership"
+}
+
+variable "consortium_name" {
+  type = "string"
+  default = "My Business Network"
+}
+
+variable "env_name" {
+  type = "string"
+  default = "Development"
+}
+
+variable "env_description" {
+  type = "string"
+  default = "Created with Terraform"
+}
+variable "network_description" {
+  type = "string"
+  default = "Modern Business Network - Built on Kaleido"
+}

--- a/examples/multi_region_customize/variables.tf
+++ b/examples/multi_region_customize/variables.tf
@@ -6,7 +6,7 @@ variable "kaleido_api_key" {
 variable "kaleido_api_url" {
   type = "string"
   description = "The regional API URL you use will determine the region your metadata is located in"
-  default = "https://console-us1.kaleido.io/api/v1"
+  default = "https://console.kaleido.io/api/v1"
 }
 
 variable "cloud" {
@@ -31,12 +31,6 @@ variable "consensus" {
   type = "string"
   default = "ibft"
   description = "Consensus mechanism."
-}
-
-variable "multi_region" {
-  type = "string"
-  default = false
-  description = "Make the environment multi-region compatible to support additional regions, now or in the future"
 }
 
 variable "node_size" {


### PR DESCRIPTION
The `simple_env` sample picks up the deployment zone implicitly from the API URL region that is used for the metadata.

This PR adds a sample that sets the deployment zone explicitly, demonstrating how you could whitelist and deploy to additional regions within a multi-region environment.