### PR TITLE
Adding support to allow reading IPFS web UI URL

### DIFF
--- a/kaleido/common_test.go
+++ b/kaleido/common_test.go
@@ -201,6 +201,45 @@ func testServiceGocks(service *kaleido.Service) {
 
 }
 
+func testIPFSServiceGocks(service *kaleido.Service) {
+
+	serviceCreateRequest := jsonClone(service)
+	serviceCreateResponse := jsonClone(serviceCreateRequest)
+	serviceCreateResponse["_id"] = "ipfs_svc1"
+	serviceCreateResponse["state"] = "provisioning"
+	serviceGetResponse1 := jsonClone(serviceCreateResponse)
+	serviceGetResponse2 := jsonClone(serviceCreateResponse)
+	serviceGetResponse2["state"] = "started"
+	serviceGetResponse2["urls"] = map[string]string{
+		"http": "http://test-http.example.com",
+		"webui": "http://test-http.example.com",
+		"websocket_url": "http://test-http.example.com",
+	}
+
+	gock.New("http://example.com").
+		Post("/api/v1/consortia/cons1/environments/env1/services").
+		MatchType("json").
+		JSON(serviceCreateRequest).
+		Reply(201).
+		JSON(serviceCreateResponse)
+
+	gock.New("http://example.com").
+		Get("/api/v1/consortia/cons1/environments/env1/services/ipfs_svc1").
+		Reply(200).
+		JSON(serviceGetResponse1)
+
+	gock.New("http://example.com").
+		Get("/api/v1/consortia/cons1/environments/env1/services/ipfs_svc1").
+		Persist().
+		Reply(200).
+		JSON(serviceGetResponse2)
+
+	gock.New("http://example.com").
+		Delete("/api/v1/consortia/cons1/environments/env1/services/ipfs_svc1").
+		Reply(204)
+
+}
+
 func testNodeGocks(node *kaleido.Node) {
 
 	nodeCreateRequest := jsonClone(node)

--- a/kaleido/resource_service.go
+++ b/kaleido/resource_service.go
@@ -71,6 +71,11 @@ func resourceService() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"webui_url": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			
 		},
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(10 * time.Minute),
@@ -134,7 +139,9 @@ func resourceServiceCreate(d *schema.ResourceData, meta interface{}) error {
 	if wsURL, ok := service.Urls["ws"]; ok {
 		d.Set("websocket_url", wsURL)
 	}
-
+	if webuiURL, ok := service.Urls["webui"]; ok {
+		d.Set("webui_url", webuiURL)
+	}
 	return nil
 }
 
@@ -167,6 +174,9 @@ func resourceServiceRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("https_url", service.Urls["http"])
 	if wsURL, ok := service.Urls["ws"]; ok {
 		d.Set("websocket_url", wsURL)
+	}
+	if webuiURL, ok := service.Urls["webui"]; ok {
+		d.Set("webui_url", webuiURL)
 	}
 	return nil
 }

--- a/kaleido/resource_service_test.go
+++ b/kaleido/resource_service_test.go
@@ -35,16 +35,19 @@ func TestKaleidoServiceResource(t *testing.T) {
 		"kms_id":        "kms1",
 		"networking_id": "networking1",
 	})
+	ipfs_service := kaleido.NewService("ipfs_service1", "ipfs", "member1", "zone1", map[string]interface{}{})
 	node := kaleido.NewNode("node1", "member1", "zone1")
 
 	consResource := "kaleido_consortium." + consortium.Name
 	membershipResource := "kaleido_membership." + membership.OrgName
 	envResource := "kaleido_environment." + environment.Name
 	serviceResource := "kaleido_service.theService"
+	ipfsServiceResource := "kaleido_service.ipfs_service"
 
 	defer gock.Off()
 	testNodeGocks(&node)
 	testServiceGocks(&service)
+	testIPFSServiceGocks(&ipfs_service)
 	testEZoneGocks(&ezone)
 	testEnvironmentGocks(&environment)
 	testMembershipGocks(&membership)
@@ -66,6 +69,7 @@ func TestKaleidoServiceResource(t *testing.T) {
 				Config: testAccServiceConfig_basic(&consortium, &membership, &environment),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckServiceExists(consResource, membershipResource, envResource, serviceResource),
+					testAccCheckServiceExists(consResource, membershipResource, envResource, ipfsServiceResource),
 					resource.TestMatchResourceAttr(serviceResource, "details.kms_id", regexp.MustCompile("kms1")),
 					resource.TestMatchResourceAttr(serviceResource, "details.backup_id", regexp.MustCompile("backupid1")),
 					resource.TestMatchResourceAttr(serviceResource, "details.networking_id", regexp.MustCompile("networking1")),
@@ -181,6 +185,15 @@ func testAccServiceConfig_basic(consortium *kaleido.Consortium, membership *kale
 				networking_id = "networking1"
 			}
     }
+    
+	resource "kaleido_service" "ipfs_service" {
+		consortium_id = "${kaleido_consortium.terraService.id}"
+		environment_id = "${kaleido_environment.serviceEnv.id}"
+		membership_id = "${kaleido_membership.kaleido.id}"
+			  zone_id = "${kaleido_ezone.theZone.id}"
+		service_type = "ipfs"
+			  name = "ipfs_service1"
+	}
     `, consortium.Name,
 		consortium.Description,
 		membership.OrgName,


### PR DESCRIPTION
This feature is based on the Kaleido API schema to return the webui for a new IPFS service