### PR TITLE
Shared tweaks

### DIFF
--- a/examples/multi_region_with_b2b/main.tf
+++ b/examples/multi_region_with_b2b/main.tf
@@ -7,7 +7,6 @@ terraform {
   required_providers {
     kaleido = {
       source = "kaleido-io/kaleido"
-      version = "0.2.1"
     }
   }
 }

--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/hashicorp/terraform-svchost v0.0.0-20191119180714-d2e4933b9136 // indirect
 	github.com/hashicorp/yamux v0.0.0-20190923154419-df201c70410d // indirect
 	github.com/jackpal/go-nat-pmp v1.0.2 // indirect
-	github.com/kaleido-io/kaleido-sdk-go v0.0.0-20210218081223-55d6261db229
+	github.com/kaleido-io/kaleido-sdk-go v0.0.0-20210219180449-3dedb144f197
 	github.com/karalabe/usb v0.0.0-20191104083709-911d15fe12a9 // indirect
 	github.com/karalabe/xgo v0.0.0-20191115072854-c5ccff8648a7 // indirect
 	github.com/magiconair/properties v1.8.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -422,6 +422,8 @@ github.com/kaleido-io/kaleido-sdk-go v0.0.0-20210218074628-9eba2667931f h1:7F8s8
 github.com/kaleido-io/kaleido-sdk-go v0.0.0-20210218074628-9eba2667931f/go.mod h1:eV0b7BMA84Z7KX0CG4RM/ms8rELCOXot+3xIu3GXN1Y=
 github.com/kaleido-io/kaleido-sdk-go v0.0.0-20210218081223-55d6261db229 h1:8IbLO6WhETTOP+/ezr9QTNPJxsiCi3rriJ1K69jwVTY=
 github.com/kaleido-io/kaleido-sdk-go v0.0.0-20210218081223-55d6261db229/go.mod h1:eV0b7BMA84Z7KX0CG4RM/ms8rELCOXot+3xIu3GXN1Y=
+github.com/kaleido-io/kaleido-sdk-go v0.0.0-20210219180449-3dedb144f197 h1:g3ckJAopXa19B/xnDpe4fEhZgk7LjBLQSekhJbNu7Lk=
+github.com/kaleido-io/kaleido-sdk-go v0.0.0-20210219180449-3dedb144f197/go.mod h1:eV0b7BMA84Z7KX0CG4RM/ms8rELCOXot+3xIu3GXN1Y=
 github.com/karalabe/usb v0.0.0-20190919080040-51dc0efba356 h1:I/yrLt2WilKxlQKCM52clh5rGzTKpVctGT1lH4Dc8Jw=
 github.com/karalabe/usb v0.0.0-20190919080040-51dc0efba356/go.mod h1:Od972xHfMJowv7NGVDiWVxk2zxnWgjLlJzE+F4F7AGU=
 github.com/karalabe/usb v0.0.0-20191104083709-911d15fe12a9 h1:ZHuwnjpP8LsVsUYqTqeVAI+GfDfJ6UNPrExZF+vX/DQ=

--- a/kaleido/resource_configuration.go
+++ b/kaleido/resource_configuration.go
@@ -71,7 +71,7 @@ func resourceConfigurationCreate(d *schema.ResourceData, meta interface{}) error
 	environmentID := d.Get("environment_id").(string)
 	membershipID := d.Get("membership_id").(string)
 	configurationType := d.Get("type").(string)
-	details := d.Get("details").(map[string]interface{})
+	details := duplicateDetails(d.Get("details").(map[string]interface{}))
 	configuration := kaleido.NewConfiguration(d.Get("name").(string), membershipID, configurationType, details)
 
 	res, err := client.CreateConfiguration(consortiumID, environmentID, &configuration)
@@ -106,7 +106,7 @@ func resourceConfigurationUpdate(d *schema.ResourceData, meta interface{}) error
 	client := meta.(kaleido.KaleidoClient)
 	consortiumID := d.Get("consortium_id").(string)
 	environmentID := d.Get("environment_id").(string)
-	details := d.Get("details").(map[string]interface{})
+	details := duplicateDetails(d.Get("details").(map[string]interface{}))
 	configuration := kaleido.NewConfiguration(d.Get("name").(string), "", "", details)
 	configID := d.Id()
 

--- a/kaleido/resource_consortium.go
+++ b/kaleido/resource_consortium.go
@@ -15,6 +15,7 @@ package kaleido
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	kaleido "github.com/kaleido-io/kaleido-sdk-go/kaleido"
@@ -62,7 +63,7 @@ func resourceConsortiumCreate(d *schema.ResourceData, meta interface{}) error {
 			return fmt.Errorf("Failed to list existing consortia with status %d: %s", res.StatusCode(), res.String())
 		}
 		for _, c := range consortia {
-			if c.Name == consortium.Name {
+			if c.Name == consortium.Name && !strings.Contains(c.State, "delete") {
 				// Already exists, just re-use
 				d.SetId(c.ID)
 				return resourceConsortiumRead(d, meta)

--- a/kaleido/resource_environment.go
+++ b/kaleido/resource_environment.go
@@ -15,6 +15,7 @@ package kaleido
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -124,7 +125,7 @@ func resourceEnvironmentCreate(d *schema.ResourceData, meta interface{}) error {
 			return fmt.Errorf("Failed to list existing environments with status %d: %s", res.StatusCode(), res.String())
 		}
 		for _, e := range environments {
-			if e.Name == environment.Name {
+			if e.Name == environment.Name && !strings.Contains(e.State, "delete") {
 				// Already exists, just re-use
 				d.SetId(e.ID)
 				return resourceEnvironmentRead(d, meta)

--- a/kaleido/resource_service.go
+++ b/kaleido/resource_service.go
@@ -15,6 +15,7 @@ package kaleido
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
@@ -139,7 +140,10 @@ func resourceServiceCreate(d *schema.ResourceData, meta interface{}) error {
 			return fmt.Errorf("Failed to list existing services with status %d: %s", res.StatusCode(), res.String())
 		}
 		for _, e := range existing {
-			if e.Service == service.Service {
+			if e.Service == service.Service && !strings.Contains(e.State, "delete") {
+				if e.ServiceType != "utility" {
+					return fmt.Errorf("The shared_deployment option only applies to utility services. %s service %s is a '%s' service", service.Service, service.ID, service.ServiceType)
+				}
 				// Already exists, just re-use
 				d.SetId(e.ID)
 				return resourceServiceRead(d, meta)


### PR DESCRIPTION
A few incremental improvements:
- The `shared_deployment` logic should ignore deleted/deleting resources
- The `shared_deployment` logic for services, should only function for `utility` services
- Avoid pass-by-reference of the Terraform `details` object to the REST API layer, as we were picking up generated info

For the last point, it's illustrated with this `terraform plan` output that shows us trying to un-set the `ipfs_peer_id` that Kaleido generated.

```
  ~ resource "kaleido_service" "ipfs" {
      ~ details           = {

          - "ipfs_peer_id"   = "QmeojRGEwaX9vK3zizHXj2ucUYfVV7bWQ7DVjZCn6VdRim" -> null

            # (1 unchanged element hidden)
        }

        id                = "zzubxbrt2f"

        name              = "sender ipfs"
        # (9 unchanged attributes hidden)

    }
```