### PR TITLE
Updates to headers, data getter for bridge config, and full list of service/node URLs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/hashicorp/terraform-plugin-sdk v1.7.0
 	github.com/hashicorp/terraform-svchost v0.0.0-20191119180714-d2e4933b9136 // indirect
 	github.com/hashicorp/yamux v0.0.0-20190923154419-df201c70410d // indirect
-	github.com/kaleido-io/kaleido-sdk-go v0.0.0-20210302035110-5b88276b26b0
+	github.com/kaleido-io/kaleido-sdk-go v0.0.0-20210317131309-d2366683444a
 	github.com/mattn/go-colorable v0.1.6 // indirect
 	github.com/mitchellh/cli v1.1.1 // indirect
 	github.com/mitchellh/go-testing-interface v1.14.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/hashicorp/terraform-plugin-sdk v1.7.0
 	github.com/hashicorp/terraform-svchost v0.0.0-20191119180714-d2e4933b9136 // indirect
 	github.com/hashicorp/yamux v0.0.0-20190923154419-df201c70410d // indirect
-	github.com/kaleido-io/kaleido-sdk-go v0.0.0-20210317131309-d2366683444a
+	github.com/kaleido-io/kaleido-sdk-go v0.0.0-20210318040509-0a49dcb1f2bf
 	github.com/mattn/go-colorable v0.1.6 // indirect
 	github.com/mitchellh/cli v1.1.1 // indirect
 	github.com/mitchellh/go-testing-interface v1.14.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -392,6 +392,8 @@ github.com/julienschmidt/httprouter v1.1.1-0.20170430222011-975b5c4c7c21/go.mod 
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/kaleido-io/kaleido-sdk-go v0.0.0-20210302035110-5b88276b26b0 h1:UBnJhiwGiIfdcnoaA3Pog4ftFDMwR5VC3HyZ0SqIFac=
 github.com/kaleido-io/kaleido-sdk-go v0.0.0-20210302035110-5b88276b26b0/go.mod h1:eV0b7BMA84Z7KX0CG4RM/ms8rELCOXot+3xIu3GXN1Y=
+github.com/kaleido-io/kaleido-sdk-go v0.0.0-20210317131309-d2366683444a h1:z+6Ffg5PTdE/9NVNnxTE985oCUnRDwlGvFBw/lKhxbk=
+github.com/kaleido-io/kaleido-sdk-go v0.0.0-20210317131309-d2366683444a/go.mod h1:eV0b7BMA84Z7KX0CG4RM/ms8rELCOXot+3xIu3GXN1Y=
 github.com/karalabe/usb v0.0.0-20190919080040-51dc0efba356 h1:I/yrLt2WilKxlQKCM52clh5rGzTKpVctGT1lH4Dc8Jw=
 github.com/karalabe/usb v0.0.0-20190919080040-51dc0efba356/go.mod h1:Od972xHfMJowv7NGVDiWVxk2zxnWgjLlJzE+F4F7AGU=
 github.com/karalabe/usb v0.0.0-20191104083709-911d15fe12a9 h1:ZHuwnjpP8LsVsUYqTqeVAI+GfDfJ6UNPrExZF+vX/DQ=

--- a/go.sum
+++ b/go.sum
@@ -394,6 +394,10 @@ github.com/kaleido-io/kaleido-sdk-go v0.0.0-20210302035110-5b88276b26b0 h1:UBnJh
 github.com/kaleido-io/kaleido-sdk-go v0.0.0-20210302035110-5b88276b26b0/go.mod h1:eV0b7BMA84Z7KX0CG4RM/ms8rELCOXot+3xIu3GXN1Y=
 github.com/kaleido-io/kaleido-sdk-go v0.0.0-20210317131309-d2366683444a h1:z+6Ffg5PTdE/9NVNnxTE985oCUnRDwlGvFBw/lKhxbk=
 github.com/kaleido-io/kaleido-sdk-go v0.0.0-20210317131309-d2366683444a/go.mod h1:eV0b7BMA84Z7KX0CG4RM/ms8rELCOXot+3xIu3GXN1Y=
+github.com/kaleido-io/kaleido-sdk-go v0.0.0-20210318040003-ebdbdcff986d h1:FLaUJ0eMVd/yYazGi93zS1LifrXf90g3g5owafGCOr0=
+github.com/kaleido-io/kaleido-sdk-go v0.0.0-20210318040003-ebdbdcff986d/go.mod h1:eV0b7BMA84Z7KX0CG4RM/ms8rELCOXot+3xIu3GXN1Y=
+github.com/kaleido-io/kaleido-sdk-go v0.0.0-20210318040509-0a49dcb1f2bf h1:4iFu+C3zp2jgPDWnCBNUERKTwFrcs7ShSVsiqezQ1og=
+github.com/kaleido-io/kaleido-sdk-go v0.0.0-20210318040509-0a49dcb1f2bf/go.mod h1:eV0b7BMA84Z7KX0CG4RM/ms8rELCOXot+3xIu3GXN1Y=
 github.com/karalabe/usb v0.0.0-20190919080040-51dc0efba356 h1:I/yrLt2WilKxlQKCM52clh5rGzTKpVctGT1lH4Dc8Jw=
 github.com/karalabe/usb v0.0.0-20190919080040-51dc0efba356/go.mod h1:Od972xHfMJowv7NGVDiWVxk2zxnWgjLlJzE+F4F7AGU=
 github.com/karalabe/usb v0.0.0-20191104083709-911d15fe12a9 h1:ZHuwnjpP8LsVsUYqTqeVAI+GfDfJ6UNPrExZF+vX/DQ=

--- a/kaleido/provider.go
+++ b/kaleido/provider.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Kaleido, a ConsenSys business
+// Copyright © Kaleido, Inc. 2018, 2021
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -46,6 +46,9 @@ func Provider() *schema.Provider {
 			"kaleido_destination":   resourceDestination(),
 		},
 		ConfigureFunc: providerConfigure,
+		DataSourcesMap: map[string]*schema.Resource{
+			"kaleido_privatestack_bridge": resourcePrivateStackBridge(),
+		},
 	}
 }
 

--- a/kaleido/provider_test.go
+++ b/kaleido/provider_test.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Kaleido, a ConsenSys business
+// Copyright © Kaleido, Inc. 2018, 2021
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/kaleido/resource_appcreds.go
+++ b/kaleido/resource_appcreds.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Kaleido, a ConsenSys business
+// Copyright © Kaleido, Inc. 2018, 2021
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/kaleido/resource_appcreds_test.go
+++ b/kaleido/resource_appcreds_test.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Kaleido, a ConsenSys business
+// Copyright © Kaleido, Inc. 2018, 2021
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/kaleido/resource_configuration.go
+++ b/kaleido/resource_configuration.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Kaleido, a ConsenSys business
+// Copyright © Kaleido, Inc. 2018, 2021
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/kaleido/resource_configuration_test.go
+++ b/kaleido/resource_configuration_test.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Kaleido, a ConsenSys business
+// Copyright © Kaleido, Inc. 2018, 2021
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/kaleido/resource_consortium.go
+++ b/kaleido/resource_consortium.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Kaleido, a ConsenSys business
+// Copyright © Kaleido, Inc. 2018, 2021
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/kaleido/resource_consortium_test.go
+++ b/kaleido/resource_consortium_test.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Kaleido, a ConsenSys business
+// Copyright © Kaleido, Inc. 2018, 2021
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/kaleido/resource_czone.go
+++ b/kaleido/resource_czone.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Kaleido, a ConsenSys business
+// Copyright © Kaleido, Inc. 2018, 2021
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/kaleido/resource_destination.go
+++ b/kaleido/resource_destination.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Kaleido, a ConsenSys business
+// Copyright © Kaleido, Inc. 2018, 2021
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/kaleido/resource_environment.go
+++ b/kaleido/resource_environment.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Kaleido, a ConsenSys business
+// Copyright © Kaleido, Inc. 2018, 2021
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/kaleido/resource_environment_test.go
+++ b/kaleido/resource_environment_test.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Kaleido, a ConsenSys business
+// Copyright © Kaleido, Inc. 2018, 2021
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/kaleido/resource_ezone.go
+++ b/kaleido/resource_ezone.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Kaleido, a ConsenSys business
+// Copyright © Kaleido, Inc. 2018, 2021
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/kaleido/resource_invitation.go
+++ b/kaleido/resource_invitation.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Kaleido, a ConsenSys business
+// Copyright © Kaleido, Inc. 2018, 2021
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/kaleido/resource_invitation_test.go
+++ b/kaleido/resource_invitation_test.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Kaleido, a ConsenSys business
+// Copyright © Kaleido, Inc. 2018, 2021
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/kaleido/resource_membership.go
+++ b/kaleido/resource_membership.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Kaleido, a ConsenSys business
+// Copyright © Kaleido, Inc. 2018, 2021
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/kaleido/resource_membership_test.go
+++ b/kaleido/resource_membership_test.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Kaleido, a ConsenSys business
+// Copyright © Kaleido, Inc. 2018, 2021
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/kaleido/resource_node.go
+++ b/kaleido/resource_node.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Kaleido, a ConsenSys business
+// Copyright © Kaleido, Inc. 2018, 2021
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/kaleido/resource_node.go
+++ b/kaleido/resource_node.go
@@ -62,6 +62,10 @@ func resourceNode() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"urls": &schema.Schema{
+				Type:     schema.TypeMap,
+				Computed: true,
+			},
 			"first_user_account": &schema.Schema{
 				Type:     schema.TypeString,
 				Computed: true,
@@ -133,6 +137,16 @@ func waitUntilNodeStarted(op, consortiumID, environmentID, nodeID string, node *
 	})
 }
 
+func setNodeUrls(d *schema.ResourceData, node *kaleido.Node) {
+	urls := make(map[string]string)
+	for name, urlValue := range node.Urls {
+		if urlString, ok := urlValue.(string); ok {
+			urls[name] = urlString
+		}
+	}
+	d.Set("urls", urls)
+}
+
 func resourceNodeCreate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(kaleido.KaleidoClient)
 	consortiumID := d.Get("consortium_id").(string)
@@ -169,8 +183,9 @@ func resourceNodeCreate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	d.SetId(node.ID)
-	d.Set("websocket_url", node.Urls.WSS)
-	d.Set("https_url", node.Urls.RPC)
+	setNodeUrls(d, &node)
+	d.Set("websocket_url", node.Urls["wss"])
+	d.Set("https_url", node.Urls["rpc"])
 	d.Set("first_user_account", node.FirstUserAccount)
 
 	return nil
@@ -246,8 +261,9 @@ func resourceNodeRead(d *schema.ResourceData, meta interface{}) error {
 
 	d.Set("name", node.Name)
 	d.Set("role", node.Role)
-	d.Set("websocket_url", node.Urls.WSS)
-	d.Set("https_url", node.Urls.RPC)
+	setNodeUrls(d, &node)
+	d.Set("websocket_url", node.Urls["wss"])
+	d.Set("https_url", node.Urls["rpc"])
 	d.Set("first_user_account", node.FirstUserAccount)
 	return nil
 }

--- a/kaleido/resource_node_test.go
+++ b/kaleido/resource_node_test.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Kaleido, a ConsenSys business
+// Copyright © Kaleido, Inc. 2018, 2021
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/kaleido/resource_privatestack_bridge.go
+++ b/kaleido/resource_privatestack_bridge.go
@@ -1,0 +1,68 @@
+// Copyright © Kaleido, Inc. 2018, 2021
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package kaleido
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	kaleido "github.com/kaleido-io/kaleido-sdk-go/kaleido"
+)
+
+func resourcePrivateStackBridge() *schema.Resource {
+	return &schema.Resource{
+		Read: resourcePrivateStackBridgeRead,
+
+		Schema: map[string]*schema.Schema{
+			"consortium_id": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"environment_id": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"service_id": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"config_json": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourcePrivateStackBridgeRead(d *schema.ResourceData, meta interface{}) error {
+
+	client := meta.(kaleido.KaleidoClient)
+
+	var conf map[string]interface{}
+	res, err := client.GetPrivateStackBridgeConfig(d.Get("consortium_id").(string), d.Get("environment_id").(string), d.Get("service_id").(string), &conf)
+
+	if err != nil {
+		return err
+	}
+
+	status := res.StatusCode()
+	if status != 200 {
+		return fmt.Errorf("Failed to read config with id %s status was: %d, error: %s", d.Id(), status, res.String())
+	}
+	d.SetId(d.Get("service_id").(string))
+	confstr, _ := json.MarshalIndent(conf, "", "  ")
+	d.Set("config_json", string(confstr))
+	return nil
+}

--- a/kaleido/resource_privatestack_bridge_test.go
+++ b/kaleido/resource_privatestack_bridge_test.go
@@ -1,0 +1,101 @@
+// Copyright © Kaleido, Inc. 2018, 2021
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package kaleido
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	gock "gopkg.in/h2non/gock.v1"
+)
+
+func TestKaleidoPrivateStackBridgeResource(t *testing.T) {
+	defer gock.Off()
+
+	gock.Observe(gock.DumpRequest)
+
+	os.Setenv("KALEIDO_API", "http://api.example.com/api/v1")
+	os.Setenv("KALEIDO_API_KEY", "ut_apikey")
+
+	mockConfig := map[string]interface{}{
+		"nested": map[string]interface{}{
+			"arrays": []int{
+				1, 2, 3, 4, 5,
+			},
+		},
+		"simple": "stringvalue",
+	}
+
+	gock.New("http://api.example.com").
+		Get("/api/v1/consortia/cons1/environments/env1/services/svc1/tunneler_config").
+		Persist().
+		Reply(200).
+		JSON(mockConfig)
+
+	pstackBridgeResource := "data.kaleido_privatestack_bridge.test"
+
+	expectedConf, _ := json.MarshalIndent(mockConfig, "", "  ")
+
+	resource.Test(t, resource.TestCase{
+		IsUnitTest:                true,
+		PreventPostDestroyRefresh: true,
+		PreCheck:                  func() { testAccPreCheck(t) },
+		Providers:                 testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testPrivateStackBridgeConfigFetch_tf(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testPrivateStackBridgeConfigFetch(pstackBridgeResource),
+					resource.TestCheckResourceAttr(pstackBridgeResource, "config_json", string(expectedConf)),
+				),
+			},
+		},
+	})
+
+}
+
+func testPrivateStackBridgeConfigFetch(pstackBridgeResource string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		r := s.RootModule().Resources
+		fmt.Printf("RETURNED: %+v", r)
+
+		configRs, ok := s.RootModule().Resources[pstackBridgeResource]
+
+		if !ok {
+			return fmt.Errorf("Not found: %s", pstackBridgeResource)
+		}
+
+		if configRs.Primary.ID != "svc1" {
+			return fmt.Errorf("Invalid ID: %+v", configRs.Primary)
+		}
+
+		return nil
+	}
+}
+
+func testPrivateStackBridgeConfigFetch_tf() string {
+	return fmt.Sprintf(`
+	
+		data "kaleido_privatestack_bridge" "test" {
+			consortium_id = "cons1"
+			environment_id = "env1"
+			service_id = "svc1"
+		}
+	
+    `)
+}

--- a/kaleido/resource_service.go
+++ b/kaleido/resource_service.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Kaleido, a ConsenSys business
+// Copyright © Kaleido, Inc. 2018, 2021
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/kaleido/resource_service.go
+++ b/kaleido/resource_service.go
@@ -85,6 +85,10 @@ func resourceService() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"urls": &schema.Schema{
+				Type:     schema.TypeMap,
+				Computed: true,
+			},
 		},
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(10 * time.Minute),
@@ -117,6 +121,16 @@ func waitUntilServiceStarted(op, consortiumID, environmentID, serviceID string, 
 
 		return nil
 	})
+}
+
+func setServiceUrls(d *schema.ResourceData, service *kaleido.Service) {
+	urls := make(map[string]string)
+	for name, urlValue := range service.Urls {
+		if urlString, ok := urlValue.(string); ok {
+			urls[name] = urlString
+		}
+	}
+	d.Set("urls", urls)
 }
 
 func resourceServiceCreate(d *schema.ResourceData, meta interface{}) error {
@@ -170,6 +184,7 @@ func resourceServiceCreate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	d.SetId(service.ID)
+	setServiceUrls(d, &service)
 	d.Set("https_url", service.Urls["http"])
 	if wsURL, ok := service.Urls["ws"]; ok {
 		d.Set("websocket_url", wsURL)
@@ -256,6 +271,7 @@ func resourceServiceRead(d *schema.ResourceData, meta interface{}) error {
 
 	d.Set("name", service.Name)
 	d.Set("service_type", service.Service)
+	setServiceUrls(d, &service)
 	d.Set("https_url", service.Urls["http"])
 	if wsURL, ok := service.Urls["ws"]; ok {
 		d.Set("websocket_url", wsURL)

--- a/kaleido/resource_service_test.go
+++ b/kaleido/resource_service_test.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Kaleido, a ConsenSys business
+// Copyright © Kaleido, Inc. 2018, 2021
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/main.go
+++ b/main.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Kaleido, a ConsenSys business
+// Copyright © Kaleido, Inc. 2018, 2021
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
- Adds a `kaleido_privatestack_bridge` `data` resource for querying the configuration of the privatestack bridge
- Allows an application credential to be mixed into the config by the provider, to provide a fully formed config
- Adds full `urls` Map output to `kaleido_service` and `kaleido_node` resources
- Updates copyright headers
- Depends on https://github.com/kaleido-io/kaleido-sdk-go/pull/36