### PR TITLE
Recording chain_id on Environment Creation

### DIFF
--- a/kaleido/resource_environment.go
+++ b/kaleido/resource_environment.go
@@ -88,6 +88,7 @@ func resourceEnvironment() *schema.Resource {
 			},
 			"chain_id": &schema.Schema{
 				Type:     schema.TypeInt,
+				Computed: true,
 				Optional: true,
 			},
 		},
@@ -124,6 +125,7 @@ func resourceEnvironmentCreate(d *schema.ResourceData, meta interface{}) error {
 	if consortiumID == "" {
 		return fmt.Errorf("Consortium missing id.")
 	}
+	chainID := uint(d.Get("chain_id").(int))
 	environment := kaleido.NewEnvironment(d.Get("name").(string),
 		d.Get("description").(string),
 		d.Get("env_type").(string),
@@ -131,7 +133,7 @@ func resourceEnvironmentCreate(d *schema.ResourceData, meta interface{}) error {
 		d.Get("multi_region").(bool),
 		d.Get("block_period").(int),
 		prefundedAccountsStringified,
-		uint(d.Get("chain_id").(int)))
+		chainID)
 
 	if err := setTestFeatures(d, client, &environment); err != nil {
 		return err
@@ -196,6 +198,10 @@ func resourceEnvironmentCreate(d *schema.ResourceData, meta interface{}) error {
 	if environment.ReleaseID != "" {
 		d.Set("release_id", environment.ReleaseID)
 	}
+	if chainID != environment.ChainID {
+		d.Set("chain_id", environment.ChainID)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
Hit a bug where the environment would appear like it needed to be changed every `apply`:
```
".terraform/terraform.tfstate" 52L, 1561C                                                                                                                                                     1,1           All
      - chain_id           = 1425291069 -> null
        id                 = "u0*****"
        name               = "Dev - Fabric"
        # (8 unchanged attributes hidden)
    }
```

looking in the `terraform.tfstate`, the recorded value was `null` since it was `Optional` but not `Computed`:
```json
      "module": "module.kaleido_fabric",
      "mode": "managed",
      "type": "kaleido_environment",
      "name": "env",
      "provider": "module.cue.module.kaleido_fabric.provider[\"registry.terraform.io/kaleido-io/kaleido\"]",
      "instances": [
        {
          "schema_version": 0,
          "attributes": {
            "block_period": null,
            "chain_id": null,
```

as a result, it'd try to do an update and for Fabric envs with `test_features` it prevent the apply from succeeding (which may be a separate 🐛  that needs to be fixed):
```
│ Error: Failed to update environment u0k3youpaq, in consortium u0hl3s242c with status 400: {"requestId":"3s0jhnd69f","errorMessage":"Immutable field test_features cannot change"}
│
│   with module.cue.module.kaleido_fabric.kaleido_environment.env,
│   on .terraform/modules/cue/modules/kaleido_fabric/main.tf line 27, in resource "kaleido_environment" "env":
│   27: resource "kaleido_environment" "env" {
│
╵
```