### PR TITLE
Avoid setting IDs to unknown in plan for update, and deliver multi-party sample

### DIFF
--- a/examples/platform_stack/main.tf
+++ b/examples/platform_stack/main.tf
@@ -2,6 +2,7 @@ terraform {
   required_providers {
     kaleido = {
       source = "kaleido-io/kaleido"
+      version = "1.1.0-rc.1"
     }
   }
 }

--- a/examples/platform_stack_multiparty_sandbox/.gitignore
+++ b/examples/platform_stack_multiparty_sandbox/.gitignore
@@ -1,0 +1,4 @@
+.terraform*
+terraform.d
+terraform.tfstate*
+terraform.tfvars

--- a/examples/platform_stack_multiparty_sandbox/main.tf
+++ b/examples/platform_stack_multiparty_sandbox/main.tf
@@ -300,6 +300,12 @@ resource "kaleido_platform_service" "member_firefly" {
   for_each = toset(var.members)
 }
 
+resource "kaleido_platform_firefly_registration" "registrations" {
+  environment = kaleido_platform_environment.env_0.id
+  service = kaleido_platform_service.member_firefly[each.key].id
+  for_each = toset(var.members)
+}
+
 resource "kaleido_platform_runtime" "asset_managers" {
   type = "AssetManager"
   name = "${each.key}_assets"

--- a/examples/platform_stack_multiparty_sandbox/main.tf
+++ b/examples/platform_stack_multiparty_sandbox/main.tf
@@ -1,0 +1,323 @@
+terraform {
+  required_providers {
+    kaleido = {
+      source = "kaleido-io/kaleido"
+      version = "1.1.0-rc.1"
+    }
+  }
+}
+
+provider "kaleido" {
+  platform_api = var.kaleido_platform_api
+  platform_username = var.kaleido_platform_username
+  platform_password = var.kaleido_platform_password
+}
+
+resource "kaleido_platform_environment" "env_0" {
+  name = var.environment_name
+}
+
+resource "kaleido_platform_network" "net_besu" {
+  type = "Besu"
+  name = "${var.environment_name}_chain"
+  environment = kaleido_platform_environment.env_0.id
+  config_json = jsonencode({
+    bootstrapOptions = {
+      qbft = {
+        blockperiodseconds = 2
+      }
+    }
+  })
+}
+
+
+resource "kaleido_platform_runtime" "bnr" {
+  type = "BesuNode"
+  name = "${var.environment_name}_chain_node_${count.index}"
+  environment = kaleido_platform_environment.env_0.id
+  config_json = jsonencode({})
+  count = var.besu_node_count
+}
+
+resource "kaleido_platform_service" "bns" {
+  type = "BesuNode"
+  name = "${var.environment_name}_chain_node_${count.index}"
+  environment = kaleido_platform_environment.env_0.id
+  runtime = kaleido_platform_runtime.bnr[count.index].id
+  config_json = jsonencode({
+    network = {
+      id = kaleido_platform_network.net_besu.id
+    }
+  })
+  count = var.besu_node_count
+}
+
+resource "kaleido_platform_network" "net_ipfs" {
+  type = "IPFS"
+  name = "${var.environment_name}_ipfs"
+  environment = kaleido_platform_environment.env_0.id
+  config_json = jsonencode({})
+}
+
+
+resource "kaleido_platform_runtime" "inr_0" {
+  type = "IPFSNode"
+  name = "ipfs_node"
+  environment = kaleido_platform_environment.env_0.id
+  config_json = jsonencode({ })
+}
+
+resource "kaleido_platform_service" "ins_0" {
+  type = "IPFSNode"
+  name = "ipfs_node"
+  environment = kaleido_platform_environment.env_0.id
+  runtime = kaleido_platform_runtime.inr_0.id
+  config_json = jsonencode({
+    network = {
+      id = kaleido_platform_network.net_ipfs.id
+    }
+  })
+}
+
+resource "kaleido_platform_runtime" "gwr_0" {
+  type = "EVMGateway"
+  name = "${var.environment_name}_evm_gateway"
+  environment = kaleido_platform_environment.env_0.id
+  config_json = jsonencode({})
+}
+
+resource "kaleido_platform_service" "gws_0" {
+  type = "EVMGateway"
+  name = "${var.environment_name}_evm_gateway"
+  environment = kaleido_platform_environment.env_0.id
+  runtime = kaleido_platform_runtime.gwr_0.id
+  config_json = jsonencode({
+    network = {
+      id =  kaleido_platform_network.net_besu.id
+    }
+  })
+}
+
+data "kaleido_platform_evm_netinfo" "gws_0" {
+  environment = kaleido_platform_environment.env_0.id
+  service = kaleido_platform_service.gws_0.id
+}
+
+resource "kaleido_platform_runtime" "kmr_0" {
+  type = "KeyManager"
+  name = "key_manager"
+  environment = kaleido_platform_environment.env_0.id
+  config_json = jsonencode({})
+}
+
+resource "kaleido_platform_service" "kms_0" {
+  type = "KeyManager"
+  name = "key_manager"
+  environment = kaleido_platform_environment.env_0.id
+  runtime = kaleido_platform_runtime.kmr_0.id
+  config_json = jsonencode({})
+}
+
+resource "kaleido_platform_kms_wallet" "seed_wallet" {
+  type = "hdwallet"
+  name = "seed_wallet"
+  environment = kaleido_platform_environment.env_0.id
+  service = kaleido_platform_service.kms_0.id
+  config_json = jsonencode({})
+}
+
+resource "kaleido_platform_kms_wallet" "org_wallets" {
+  type = "hdwallet"
+  name = "${each.key}_wallet"
+  environment = kaleido_platform_environment.env_0.id
+  service = kaleido_platform_service.kms_0.id
+  config_json = jsonencode({})
+  for_each = toset(var.members)
+}
+
+resource "kaleido_platform_kms_key" "seed_key" {
+  name = "seed_key"
+  environment = kaleido_platform_environment.env_0.id
+  service = kaleido_platform_service.kms_0.id
+  wallet = kaleido_platform_kms_wallet.seed_wallet.id
+}
+
+resource "kaleido_platform_kms_key" "org_keys" {
+  name = "${each.key}_org_key"
+  environment = kaleido_platform_environment.env_0.id
+  service = kaleido_platform_service.kms_0.id
+  wallet = kaleido_platform_kms_wallet.org_wallets[each.key].id
+  for_each = toset(var.members)
+}
+
+resource "kaleido_platform_runtime" "tmr_0" {
+  type = "TransactionManager"
+  name = "${var.environment_name}_chain_txmanager"
+  environment = kaleido_platform_environment.env_0.id
+  config_json = jsonencode({})
+}
+
+resource "kaleido_platform_service" "tms_0" {
+  type = "TransactionManager"
+  name = "${var.environment_name}_chain_txmanager"
+  environment = kaleido_platform_environment.env_0.id
+  runtime = kaleido_platform_runtime.tmr_0.id
+  config_json = jsonencode({
+    keyManager = {
+      id: kaleido_platform_service.kms_0.id
+    }
+    type = "evm"
+    evm = {
+      confirmations = {
+        required = 0
+      }
+      connector = {
+        evmGateway = {
+          id =  kaleido_platform_service.gws_0.id
+        }
+        # url = var.json_rpc_url
+        # auth = {
+        #   credSetRef = "rpc_auth"
+        # }
+      }
+    }
+  })
+  # cred_sets = {
+  #   "rpc_auth" = {
+  #     type = "basic_auth"
+  #     basic_auth = {
+  #       username = var.json_rpc_username
+  #       password = var.json_rpc_password
+  #     }
+  #   }
+  # }
+}
+
+resource "kaleido_platform_runtime" "ffr_0" {
+  type = "FireFly"
+  name = "firefly_runtime"
+  environment = kaleido_platform_environment.env_0.id
+  config_json = jsonencode({})
+}
+
+resource "kaleido_platform_service" "seed_firefly" {
+  type = "FireFly"
+  name = "seed"
+  environment = kaleido_platform_environment.env_0.id
+  runtime = kaleido_platform_runtime.ffr_0.id
+  config_json = jsonencode({
+    transactionManager = {
+      id = kaleido_platform_service.tms_0.id
+    }
+  })
+}
+
+resource "kaleido_platform_runtime" "pdr_0" {
+  type = "PrivateDataManager"
+  name = "data_manager"
+  environment = kaleido_platform_environment.env_0.id
+  config_json = jsonencode({})
+}
+
+
+resource "kaleido_platform_service" "pds_0" {
+  type = "PrivateDataManager"
+  name = "data_manager"
+  environment = kaleido_platform_environment.env_0.id
+  runtime = kaleido_platform_runtime.pdr_0.id
+  config_json = jsonencode({
+    dataExchangeType = "https"
+  })
+}
+
+
+resource "kaleido_platform_runtime" "cmr_0" {
+  type = "ContractManager"
+  name = "contract_manager"
+  environment = kaleido_platform_environment.env_0.id
+  config_json = jsonencode({})
+}
+
+resource "kaleido_platform_service" "cms_0" {
+  type = "ContractManager"
+  name = "contract_manager"
+  environment = kaleido_platform_environment.env_0.id
+  runtime = kaleido_platform_runtime.cmr_0.id
+  config_json = jsonencode({})
+}
+
+resource "kaleido_platform_cms_build" "firefly_batch_pin" {
+  environment = kaleido_platform_environment.env_0.id
+  service = kaleido_platform_service.cms_0.id
+  type = "github"
+  name = "batch_pin_v1.3"
+  path = "firefly"
+	github = {
+		contract_url = "https://github.com/hyperledger/firefly/blob/main/smart_contracts/ethereum/solidity_firefly/contracts/Firefly.sol"
+		contract_name = "Firefly"
+	}
+}
+
+resource "kaleido_platform_cms_action_deploy" "firefly_batch_pin" {
+  environment = kaleido_platform_environment.env_0.id
+  service = kaleido_platform_service.cms_0.id
+  build = kaleido_platform_cms_build.firefly_batch_pin.id
+  name = "firefly_batch_pin"
+  firefly_namespace = kaleido_platform_service.seed_firefly.name
+  signing_key = kaleido_platform_kms_key.seed_key.address
+  depends_on = [ data.kaleido_platform_evm_netinfo.gws_0 ]
+}
+
+resource "kaleido_platform_service" "member_firefly" {
+  type = "FireFly"
+  name = "${each.key}_firefly"
+  environment = kaleido_platform_environment.env_0.id
+  runtime = kaleido_platform_runtime.ffr_0.id
+  config_json = jsonencode({
+    transactionManager = {
+      id = kaleido_platform_service.tms_0.id
+    }
+    ipfs = {
+      ipfsService = {
+        id = kaleido_platform_service.ins_0.id
+      }
+    }
+    privatedatamanager = {
+      id = kaleido_platform_service.pds_0.id
+    }
+    multiparty = {
+      enabled = true
+      orgName = each.key
+      orgKey = kaleido_platform_kms_key.org_keys[each.key].address
+      contracts = [
+          {
+            address = kaleido_platform_cms_action_deploy.firefly_batch_pin.contract_address
+            blockNumber= kaleido_platform_cms_action_deploy.firefly_batch_pin.block_number
+          }
+      ]
+    }
+  })
+  for_each = toset(var.members)
+}
+
+resource "kaleido_platform_runtime" "asset_managers" {
+  type = "AssetManager"
+  name = "${each.key}_assets"
+  environment = kaleido_platform_environment.env_0.id
+  config_json = jsonencode({})
+  for_each = toset(var.members)
+}
+
+resource "kaleido_platform_service" "asset_managers" {
+  type = "AssetManager"
+  name = "${each.key}_assets"
+  environment = kaleido_platform_environment.env_0.id
+  runtime = kaleido_platform_runtime.asset_managers[each.key].id
+  config_json = jsonencode({
+    keyManager = {
+      id: kaleido_platform_service.kms_0.id
+    }
+  })
+  for_each = toset(var.members)
+}
+

--- a/examples/platform_stack_multiparty_sandbox/variables.tf
+++ b/examples/platform_stack_multiparty_sandbox/variables.tf
@@ -1,0 +1,24 @@
+variable "kaleido_platform_api" {
+  type = string
+}
+
+variable "kaleido_platform_username" {
+  type = string
+}
+
+variable "kaleido_platform_password" {
+  type = string
+}
+
+variable "environment_name" {
+  type = string
+}
+
+variable "besu_node_count" {
+  type = number
+  default = 1
+}
+
+variable "members" {
+  type = list(string)
+}

--- a/kaleido/platform/ams_task.go
+++ b/kaleido/platform/ams_task.go
@@ -60,7 +60,8 @@ func (r *ams_taskResource) Schema(_ context.Context, _ resource.SchemaRequest, r
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
 			"id": &schema.StringAttribute{
-				Computed: true,
+				Computed:      true,
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
 			"environment": &schema.StringAttribute{
 				Required:      true,

--- a/kaleido/platform/cms_action_create_api.go
+++ b/kaleido/platform/cms_action_create_api.go
@@ -91,7 +91,8 @@ func (r *cms_action_creatapiResource) Schema(_ context.Context, _ resource.Schem
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
 			"id": &schema.StringAttribute{
-				Computed: true,
+				Computed:      true,
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
 			"environment": &schema.StringAttribute{
 				Required:      true,

--- a/kaleido/platform/cms_action_deploy.go
+++ b/kaleido/platform/cms_action_deploy.go
@@ -98,7 +98,8 @@ func (r *cms_action_deployResource) Schema(_ context.Context, _ resource.SchemaR
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
 			"id": &schema.StringAttribute{
-				Computed: true,
+				Computed:      true,
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
 			"environment": &schema.StringAttribute{
 				Required:      true,

--- a/kaleido/platform/cms_build.go
+++ b/kaleido/platform/cms_build.go
@@ -116,7 +116,8 @@ func (r *cms_buildResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
 			"id": &schema.StringAttribute{
-				Computed: true,
+				Computed:      true,
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
 			"environment": &schema.StringAttribute{
 				Required:      true,

--- a/kaleido/platform/common.go
+++ b/kaleido/platform/common.go
@@ -238,5 +238,6 @@ func Resources() []func() resource.Resource {
 		CMSActionDeployResourceFactory,
 		CMSActionCreateAPIResourceFactory,
 		AMSTaskResourceFactory,
+		FireFlyRegistrationResourceFactory,
 	}
 }

--- a/kaleido/platform/environment.go
+++ b/kaleido/platform/environment.go
@@ -21,6 +21,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
@@ -52,7 +54,8 @@ func (r *environmentResource) Schema(_ context.Context, _ resource.SchemaRequest
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
 			"id": &schema.StringAttribute{
-				Computed: true,
+				Computed:      true,
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
 			"name": &schema.StringAttribute{
 				Required: true,

--- a/kaleido/platform/firefly_registration.go
+++ b/kaleido/platform/firefly_registration.go
@@ -1,0 +1,200 @@
+// Copyright © Kaleido, Inc. 2024
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package platform
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/kaleido-io/terraform-provider-kaleido/kaleido/kaleidobase"
+)
+
+type FireFlyRegistrationResourceModel struct {
+	Environment  types.String `tfsdk:"environment"`
+	Service      types.String `tfsdk:"service"`
+	OrgID        types.String `tfsdk:"org_id"`
+	OrgDID       types.String `tfsdk:"org_did"`
+	OrgVerifiers types.Set    `tfsdk:"org_verifiers"`
+	NodeID       types.String `tfsdk:"node_id"`
+}
+
+type FireFlyStatusAPIModel struct {
+	Node FireFlyStatusNodeAPIModel `json:"node"`
+	Org  FireFlyStatusOrgAPIModel  `json:"org"`
+}
+
+type FireFlyStatusOrgAPIModel struct {
+	Name       string                          `json:"name"`
+	Registered bool                            `json:"registered"`
+	DID        string                          `json:"did"`
+	ID         string                          `json:"id"`
+	Verifiers  []FireFlyStatusVerifierAPIModel `json:"verifiers"`
+}
+
+type FireFlyStatusNodeAPIModel struct {
+	Name       string `json:"name"`
+	Registered bool   `json:"registered"`
+	ID         string `json:"id"`
+}
+
+type FireFlyStatusVerifierAPIModel struct {
+	Type  string `json:"type"`
+	Value string `json:"value"`
+}
+
+func FireFlyRegistrationResourceFactory() resource.Resource {
+	return &firefly_registrationResource{}
+}
+
+type firefly_registrationResource struct {
+	commonResource
+}
+
+func (r *firefly_registrationResource) Metadata(_ context.Context, _ resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = "kaleido_platform_firefly_registration"
+}
+
+func (r *firefly_registrationResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"environment": &schema.StringAttribute{
+				Required:      true,
+				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
+			},
+			"service": &schema.StringAttribute{
+				Required:      true,
+				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
+			},
+			"org_id": &schema.StringAttribute{
+				Computed: true,
+			},
+			"org_did": &schema.StringAttribute{
+				Computed: true,
+			},
+			"org_verifiers": &schema.SetAttribute{
+				Computed:    true,
+				ElementType: types.StringType,
+			},
+			"node_id": &schema.StringAttribute{
+				Computed: true,
+			},
+		},
+	}
+}
+
+func (api *FireFlyStatusAPIModel) toData(data *FireFlyRegistrationResourceModel, diagnostics *diag.Diagnostics) bool {
+	if api.Node.Registered && api.Org.Registered {
+		data.OrgDID = types.StringValue(api.Org.DID)
+		data.OrgID = types.StringValue(api.Org.ID)
+		verifiers := make([]attr.Value, len(api.Org.Verifiers))
+		for i, v := range api.Org.Verifiers {
+			verifiers[i] = types.StringValue(v.Value)
+		}
+		verifiersSet, diag := types.SetValue(types.StringType, verifiers)
+		diagnostics.Append(diag...)
+		data.OrgVerifiers = verifiersSet
+		data.NodeID = types.StringValue(api.Node.ID)
+		return true
+	}
+	return false
+}
+
+func (r *firefly_registrationResource) apiPath(data *FireFlyRegistrationResourceModel, fireflyPath string) string {
+	return fmt.Sprintf("/endpoint/%s/%s/rest/api/v1/%s", data.Environment.ValueString(), data.Service.ValueString(), fireflyPath)
+}
+
+func (r *firefly_registrationResource) ensureRegistered(ctx context.Context, data *FireFlyRegistrationResourceModel, diagnostics *diag.Diagnostics) {
+	var status FireFlyStatusAPIModel
+	nodeSubmitted := false
+	orgSubmitted := false
+	cancelInfo := APICancelInfo()
+	_ = kaleidobase.Retry.Do(ctx, "register", func(attempt int) (retry bool, err error) {
+		ok, _ := r.apiRequest(ctx, http.MethodGet, r.apiPath(data, "status"), nil, &status, diagnostics, cancelInfo)
+		if !ok {
+			return false, fmt.Errorf("status-check failed") // already set in diag
+		}
+		if registered := status.toData(data, diagnostics); registered {
+			return false, nil
+		}
+		if !status.Org.Registered {
+			if !orgSubmitted {
+				ok, _ := r.apiRequest(ctx, http.MethodPost, r.apiPath(data, "network/organizations/self"), struct{}{}, nil, diagnostics, cancelInfo)
+				if !ok {
+					return false, fmt.Errorf("org-register failed") // already set in diag
+				}
+				orgSubmitted = true
+			}
+		} else if !status.Node.Registered {
+			if !nodeSubmitted {
+				ok, _ := r.apiRequest(ctx, http.MethodPost, r.apiPath(data, "network/nodes/self"), struct{}{}, nil, diagnostics, cancelInfo)
+				if !ok {
+					return false, fmt.Errorf("node-register failed") // already set in diag
+				}
+				nodeSubmitted = true
+			}
+		}
+		return true, fmt.Errorf("waiting for registration to complete")
+	})
+}
+
+func (r *firefly_registrationResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+
+	var data FireFlyRegistrationResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+
+	r.ensureRegistered(ctx, &data, &resp.Diagnostics)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, data)...)
+
+}
+
+func (r *firefly_registrationResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+
+	var data FireFlyRegistrationResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+
+	r.ensureRegistered(ctx, &data, &resp.Diagnostics)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, data)...)
+}
+
+func (r *firefly_registrationResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var data FireFlyRegistrationResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+
+	var status FireFlyStatusAPIModel
+	ok, _ := r.apiRequest(ctx, http.MethodGet, r.apiPath(&data, "status"), nil, &status, &resp.Diagnostics)
+	if !ok {
+		return
+	}
+	if registered := status.toData(&data, &resp.Diagnostics); !registered {
+		// We're not registered, remove the registration resource
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, data)...)
+}
+
+func (r *firefly_registrationResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	// no-op
+}

--- a/kaleido/platform/firefly_registration_test.go
+++ b/kaleido/platform/firefly_registration_test.go
@@ -1,0 +1,104 @@
+// Copyright © Kaleido, Inc. 2024
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package platform
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/aidarkhanov/nanoid"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/stretchr/testify/assert"
+
+	_ "embed"
+)
+
+var firefly_registrationStep1 = `
+resource "kaleido_platform_firefly_registration" "firefly_registration1" {
+    environment = "env1"
+	service = "service1"
+}
+`
+
+func TestFireFlyRegistration1(t *testing.T) {
+
+	mp, providerConfig := testSetup(t)
+	defer func() {
+		mp.checkClearCalls([]string{
+			"GET /endpoint/{env}/{service}/rest/api/v1/status",
+			"POST /endpoint/{env}/{service}/rest/api/v1/network/organizations/self",
+			"GET /endpoint/{env}/{service}/rest/api/v1/status",
+			"POST /endpoint/{env}/{service}/rest/api/v1/network/nodes/self",
+			"GET /endpoint/{env}/{service}/rest/api/v1/status",
+			"GET /endpoint/{env}/{service}/rest/api/v1/status",
+		})
+		mp.server.Close()
+	}()
+
+	firefly_registration1Resource := "kaleido_platform_firefly_registration.firefly_registration1"
+	resource.Test(t, resource.TestCase{
+		IsUnitTest:               true,
+		ProtoV6ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: providerConfig + firefly_registrationStep1,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet(firefly_registration1Resource, "org_did"),
+					resource.TestCheckResourceAttr(firefly_registration1Resource, "org_verifiers.#", "1"),
+					func(s *terraform.State) error {
+						assert.Equal(t, mp.ffsNode.ID, s.RootModule().Resources[firefly_registration1Resource].Primary.Attributes["node_id"])
+						assert.Equal(t, mp.ffsOrg.ID, s.RootModule().Resources[firefly_registration1Resource].Primary.Attributes["org_id"])
+						assert.Equal(t, mp.ffsOrg.DID, s.RootModule().Resources[firefly_registration1Resource].Primary.Attributes["org_did"])
+						assert.Equal(t, mp.ffsOrg.Verifiers[0].Value, s.RootModule().Resources[firefly_registration1Resource].Primary.Attributes["org_verifiers.0"])
+						return nil
+					},
+				),
+			},
+		},
+	})
+}
+
+func (mp *mockPlatform) postFireFlyRegistrationNode(res http.ResponseWriter, _ *http.Request) {
+	mp.ffsNode = &FireFlyStatusNodeAPIModel{
+		Registered: true,
+		Name:       "node1",
+		ID:         nanoid.New(),
+	}
+	mp.respond(res, nil, 204)
+}
+
+func (mp *mockPlatform) postFireFlyRegistrationOrg(res http.ResponseWriter, _ *http.Request) {
+	mp.ffsOrg = &FireFlyStatusOrgAPIModel{
+		Registered: true,
+		Name:       "org1",
+		ID:         nanoid.New(),
+		DID:        "did:firefly:org/org1",
+		Verifiers: []FireFlyStatusVerifierAPIModel{
+			{Type: "ethereum_address", Value: nanoid.New()},
+		},
+	}
+	mp.respond(res, nil, 204)
+}
+
+func (mp *mockPlatform) getFireFlyStatus(res http.ResponseWriter, _ *http.Request) {
+	var status FireFlyStatusAPIModel
+	if mp.ffsNode != nil {
+		status.Node = *mp.ffsNode
+	}
+	if mp.ffsOrg != nil {
+		status.Org = *mp.ffsOrg
+	}
+	mp.respond(res, &status, 200)
+}

--- a/kaleido/platform/kms_key.go
+++ b/kaleido/platform/kms_key.go
@@ -65,7 +65,8 @@ func (r *kms_keyResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
 			"id": &schema.StringAttribute{
-				Computed: true,
+				Computed:      true,
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
 			"environment": &schema.StringAttribute{
 				Required:      true,

--- a/kaleido/platform/kms_wallet.go
+++ b/kaleido/platform/kms_wallet.go
@@ -62,7 +62,8 @@ func (r *kms_walletResource) Schema(_ context.Context, _ resource.SchemaRequest,
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
 			"id": &schema.StringAttribute{
-				Computed: true,
+				Computed:      true,
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
 			"environment": &schema.StringAttribute{
 				Required:      true,

--- a/kaleido/platform/mockserver_test.go
+++ b/kaleido/platform/mockserver_test.go
@@ -45,6 +45,8 @@ type mockPlatform struct {
 	cmsBuilds    map[string]*CMSBuildAPIModel
 	cmsActions   map[string]CMSActionAPIBaseAccessor
 	amsTasks     map[string]*AMSTaskAPIModel
+	ffsNode      *FireFlyStatusNodeAPIModel
+	ffsOrg       *FireFlyStatusOrgAPIModel
 	calls        []string
 }
 
@@ -115,6 +117,11 @@ func startMockPlatformServer(t *testing.T) *mockPlatform {
 	mp.register("/endpoint/{env}/{service}/rest/api/v1/tasks/{task}", http.MethodGet, mp.getAMSTask)
 	mp.register("/endpoint/{env}/{service}/rest/api/v1/tasks/{task}", http.MethodPut, mp.putAMSTask)
 	mp.register("/endpoint/{env}/{service}/rest/api/v1/tasks/{task}", http.MethodDelete, mp.deleteAMSTask)
+
+	// See firefly_registration.go
+	mp.register("/endpoint/{env}/{service}/rest/api/v1/network/nodes/self", http.MethodPost, mp.postFireFlyRegistrationNode)
+	mp.register("/endpoint/{env}/{service}/rest/api/v1/network/organizations/self", http.MethodPost, mp.postFireFlyRegistrationOrg)
+	mp.register("/endpoint/{env}/{service}/rest/api/v1/status", http.MethodGet, mp.getFireFlyStatus)
 
 	mp.server = httptest.NewServer(mp.router)
 	return mp

--- a/kaleido/platform/network.go
+++ b/kaleido/platform/network.go
@@ -67,7 +67,8 @@ func (r *networkResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
 			"id": &schema.StringAttribute{
-				Computed: true,
+				Computed:      true,
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
 			"type": &schema.StringAttribute{
 				Required:      true,

--- a/kaleido/platform/runtime.go
+++ b/kaleido/platform/runtime.go
@@ -71,7 +71,8 @@ func (r *runtimeResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
 			"id": &schema.StringAttribute{
-				Computed: true,
+				Computed:      true,
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
 			"type": &schema.StringAttribute{
 				Required:      true,

--- a/kaleido/platform/service.go
+++ b/kaleido/platform/service.go
@@ -119,7 +119,8 @@ func (r *serviceResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
 			"id": &schema.StringAttribute{
-				Computed: true,
+				Computed:      true,
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
 			"environment": &schema.StringAttribute{
 				Required:      true,

--- a/kaleido/resource_appcreds.go
+++ b/kaleido/resource_appcreds.go
@@ -49,7 +49,8 @@ func (r *resourceAppCreds) Schema(_ context.Context, _ resource.SchemaRequest, r
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
 			"id": &schema.StringAttribute{
-				Computed: true,
+				Computed:      true,
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
 			"membership_id": &schema.StringAttribute{
 				Required:      true,

--- a/kaleido/resource_configuration.go
+++ b/kaleido/resource_configuration.go
@@ -57,7 +57,8 @@ func (r *resourceConfiguration) Schema(_ context.Context, _ resource.SchemaReque
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
 			"id": &schema.StringAttribute{
-				Computed: true,
+				Computed:      true,
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
 			"name": &schema.StringAttribute{
 				Required: true,

--- a/kaleido/resource_consortium.go
+++ b/kaleido/resource_consortium.go
@@ -22,6 +22,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	kaleido "github.com/kaleido-io/kaleido-sdk-go/kaleido"
 )
@@ -49,7 +51,8 @@ func (r *resourceConsortium) Schema(_ context.Context, _ resource.SchemaRequest,
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
 			"id": &schema.StringAttribute{
-				Computed: true,
+				Computed:      true,
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
 			"name": &schema.StringAttribute{
 				Required: true,

--- a/kaleido/resource_czone.go
+++ b/kaleido/resource_czone.go
@@ -50,7 +50,8 @@ func (r *resourceCZone) Schema(_ context.Context, _ resource.SchemaRequest, resp
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
 			"id": &schema.StringAttribute{
-				Computed: true,
+				Computed:      true,
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
 			"name": &schema.StringAttribute{
 				Optional: true,

--- a/kaleido/resource_destination.go
+++ b/kaleido/resource_destination.go
@@ -55,7 +55,8 @@ func (r *resourceDestination) Schema(_ context.Context, _ resource.SchemaRequest
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
 			"id": &schema.StringAttribute{
-				Computed: true,
+				Computed:      true,
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
 			"service_type": &schema.StringAttribute{
 				Required:      true,

--- a/kaleido/resource_environment.go
+++ b/kaleido/resource_environment.go
@@ -61,7 +61,8 @@ func (r *resourceEnvironment) Schema(_ context.Context, _ resource.SchemaRequest
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
 			"id": &schema.StringAttribute{
-				Computed: true,
+				Computed:      true,
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
 			"consortium_id": &schema.StringAttribute{
 				Required:      true,

--- a/kaleido/resource_ezone.go
+++ b/kaleido/resource_ezone.go
@@ -54,7 +54,8 @@ func (r *resourceEZone) Schema(_ context.Context, _ resource.SchemaRequest, resp
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
 			"id": &schema.StringAttribute{
-				Computed: true,
+				Computed:      true,
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
 			"name": &schema.StringAttribute{
 				Optional: true,

--- a/kaleido/resource_invitation.go
+++ b/kaleido/resource_invitation.go
@@ -49,7 +49,8 @@ func (r *resourceInvitation) Schema(_ context.Context, _ resource.SchemaRequest,
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
 			"id": &schema.StringAttribute{
-				Computed: true,
+				Computed:      true,
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
 			"consortium_id": &schema.StringAttribute{
 				Required:      true,

--- a/kaleido/resource_membership.go
+++ b/kaleido/resource_membership.go
@@ -51,7 +51,8 @@ func (r *resourceMembership) Schema(_ context.Context, _ resource.SchemaRequest,
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
 			"id": &schema.StringAttribute{
-				Computed: true,
+				Computed:      true,
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
 			"consortium_id": &schema.StringAttribute{
 				Required:      true,

--- a/kaleido/resource_node.go
+++ b/kaleido/resource_node.go
@@ -71,7 +71,8 @@ func (r *resourceNode) Schema(_ context.Context, _ resource.SchemaRequest, resp 
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
 			"id": &schema.StringAttribute{
-				Computed: true,
+				Computed:      true,
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
 			"name": &schema.StringAttribute{
 				Required: true,

--- a/kaleido/resource_service.go
+++ b/kaleido/resource_service.go
@@ -67,7 +67,8 @@ func (r *resourceService) Schema(_ context.Context, _ resource.SchemaRequest, re
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
 			"id": &schema.StringAttribute{
-				Computed: true,
+				Computed:      true,
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
 			"name": &schema.StringAttribute{
 				Required: true,


### PR DESCRIPTION
Work in progress - list will grow:
- [x] `id` fields all `UseStateForUnknown()` to avoid recreation of downstream resources if the upstream is updated
   - Without this a rename of a `kaleido_platform_runtime`, causes the `kaleido_platform_services` to recreate
- [x] Multi-party sandbox sample - minimal footprint environment for multi-party
   - Shared blockchain node(s)
   - Shared IPFS node(s)
   - Shared contract manager, transaction manager, and key manager services/runtimes
   - Shared FireFly runtime, but dedicated FireFly service/namespace per member
   - Wallet per member (in shared key manager)
   - Seed based deployment of batch pin smart contract, using a separate wallet + gateway-mode FireFly
   - Asset Manager per member
- [x] FireFly multi-party registration resource
    - `kaleido_platform_firefly_registration`