### PR TITLE
API change: Split out task version APIs to allow `description` and `exampleInput` on ver

### DIFF
--- a/examples/platform_stack/main.tf
+++ b/examples/platform_stack/main.tf
@@ -284,8 +284,8 @@ resource "kaleido_platform_ams_task" "erc20_indexer" {
   environment = kaleido_platform_environment.env_0.id
   service = kaleido_platform_service.ams_0.id
   depends_on = [ kaleido_platform_ams_task.erc20_indexer ]
+  name = "erc20_indexer"
   task_yaml = <<EOT
-    name: erc20_indexer
     steps:
     - dynamicOptions:
         assets: |-
@@ -365,8 +365,8 @@ resource "kaleido_platform_ams_fflistener" "erc20_indexer" {
 resource "kaleido_platform_ams_task" "erc721_indexer" {
   environment = kaleido_platform_environment.env_0.id
   service = kaleido_platform_service.ams_0.id
+  name = "erc721_indexer"
   task_yaml = <<EOT
-    name: erc721_indexer
     steps:
     - dynamicOptions:
         body: |-

--- a/kaleido/platform/ams_task_test.go
+++ b/kaleido/platform/ams_task_test.go
@@ -67,9 +67,11 @@ func TestAMSTask1(t *testing.T) {
 	defer func() {
 		mp.checkClearCalls([]string{
 			"PUT /endpoint/{env}/{service}/rest/api/v1/tasks/{task}", // by name initially
+			"POST /endpoint/{env}/{service}/rest/api/v1/tasks/{task}/versions",
 			"GET /endpoint/{env}/{service}/rest/api/v1/tasks/{task}",
 			"GET /endpoint/{env}/{service}/rest/api/v1/tasks/{task}",
-			"PUT /endpoint/{env}/{service}/rest/api/v1/tasks/{task}", // then by ID
+			"PATCH /endpoint/{env}/{service}/rest/api/v1/tasks/{task}", // then by ID
+			"POST /endpoint/{env}/{service}/rest/api/v1/tasks/{task}/versions",
 			"GET /endpoint/{env}/{service}/rest/api/v1/tasks/{task}",
 			"DELETE /endpoint/{env}/{service}/rest/api/v1/tasks/{task}",
 			"GET /endpoint/{env}/{service}/rest/api/v1/tasks/{task}",
@@ -98,9 +100,10 @@ func TestAMSTask1(t *testing.T) {
 						// Compare the final result on the mock-server side
 						id := s.RootModule().Resources[ams_task1Resource].Primary.Attributes["id"]
 						obj := mp.amsTasks[fmt.Sprintf("env1/service1/%s", id)]
-						testYAMLEqual(t, obj, fmt.Sprintf(`{
+						testJSONEqual(t, obj, fmt.Sprintf(`{
 								"id": "%[1]s",
 								"name": "ams_task1",
+								"description": "shiny task that does stuff and more stuff",
 								"created": "%[2]s",
 								"updated": "%[3]s",
 								"currentVersion": "%[4]s"
@@ -133,18 +136,35 @@ func (mp *mockPlatform) putAMSTask(res http.ResponseWriter, req *http.Request) {
 	obj := mp.amsTasks[mux.Vars(req)["env"]+"/"+mux.Vars(req)["service"]+"/"+mux.Vars(req)["task"]] // expected behavior of provider is PUT only on exists
 	var newObj AMSTaskAPIModel
 	mp.getBody(req, &newObj)
-	if obj == nil {
-		assert.Equal(mp.t, newObj.Name, mux.Vars(req)["task"])
-		newObj.ID = nanoid.New()
-		newObj.Created = now.Format(time.RFC3339Nano)
-	} else {
-		assert.Equal(mp.t, obj.ID, mux.Vars(req)["task"])
-		newObj.ID = mux.Vars(req)["task"]
-		newObj.Created = obj.Created
-	}
+	assert.Nil(mp.t, obj)
+	assert.Equal(mp.t, newObj.Name, mux.Vars(req)["task"])
+	newObj.ID = nanoid.New()
+	newObj.Created = now.Format(time.RFC3339Nano)
 	newObj.Updated = now.Format(time.RFC3339Nano)
 	newObj.CurrentVersion = nanoid.New()
 	mp.amsTasks[mux.Vars(req)["env"]+"/"+mux.Vars(req)["service"]+"/"+newObj.ID] = &newObj
+	mp.respond(res, &newObj, 200)
+}
+
+func (mp *mockPlatform) patchAMSTask(res http.ResponseWriter, req *http.Request) {
+	now := time.Now().UTC()
+	obj := mp.amsTasks[mux.Vars(req)["env"]+"/"+mux.Vars(req)["service"]+"/"+mux.Vars(req)["task"]] // expected behavior of provider is PUT only on exists
+	var newObj AMSTaskAPIModel
+	mp.getBody(req, &newObj)
+	assert.NotNil(mp.t, obj)
+	assert.Equal(mp.t, obj.ID, mux.Vars(req)["task"])
+	newObj.ID = mux.Vars(req)["task"]
+	newObj.Created = obj.Created
+	newObj.Updated = now.Format(time.RFC3339Nano)
+	newObj.CurrentVersion = nanoid.New()
+	mp.amsTasks[mux.Vars(req)["env"]+"/"+mux.Vars(req)["service"]+"/"+newObj.ID] = &newObj
+	mp.respond(res, &newObj, 200)
+}
+
+func (mp *mockPlatform) postAMSTaskVersion(res http.ResponseWriter, req *http.Request) {
+	var newObj map[string]interface{}
+	mp.getBody(req, &newObj)
+	mp.amsTaskVersions[mux.Vars(req)["env"]+"/"+mux.Vars(req)["service"]+"/"+mux.Vars(req)["task"]] = newObj
 	mp.respond(res, &newObj, 200)
 }
 

--- a/kaleido/platform/ams_task_test.go
+++ b/kaleido/platform/ams_task_test.go
@@ -32,8 +32,8 @@ var ams_taskStep1 = `
 resource "kaleido_platform_ams_task" "ams_task1" {
     environment = "env1"
 	service = "service1"
+	name = "ams_task1"
     task_yaml = yamlencode({
-		name = "ams_task1"
 		steps = [{
           name = "step1"
 		  things = "stuff"
@@ -46,9 +46,10 @@ var ams_taskStep2 = `
 resource "kaleido_platform_ams_task" "ams_task1" {
     environment = "env1"
 	service = "service1"
+	name = "ams_task1"
+	description = "shiny task that does stuff and more stuff"
     task_yaml = yamlencode({
-		name = "ams_task1"
-		description = "shiny task that does stuff and more stuff"
+		description = "this version is super and great, note this is a different description"
 		steps = [{
           name = "step1"
 		  things = "stuff"

--- a/kaleido/platform/mockserver_test.go
+++ b/kaleido/platform/mockserver_test.go
@@ -32,40 +32,42 @@ import (
 )
 
 type mockPlatform struct {
-	t              *testing.T
-	lock           sync.Mutex
-	router         *mux.Router
-	server         *httptest.Server
-	environments   map[string]*EnvironmentAPIModel
-	runtimes       map[string]*RuntimeAPIModel
-	services       map[string]*ServiceAPIModel
-	networks       map[string]*NetworkAPIModel
-	kmsWallets     map[string]*KMSWalletAPIModel
-	kmsKeys        map[string]*KMSKeyAPIModel
-	cmsBuilds      map[string]*CMSBuildAPIModel
-	cmsActions     map[string]CMSActionAPIBaseAccessor
-	amsTasks       map[string]*AMSTaskAPIModel
-	amsFFListeners map[string]*AMSFFListenerAPIModel
-	ffsNode        *FireFlyStatusNodeAPIModel
-	ffsOrg         *FireFlyStatusOrgAPIModel
-	calls          []string
+	t               *testing.T
+	lock            sync.Mutex
+	router          *mux.Router
+	server          *httptest.Server
+	environments    map[string]*EnvironmentAPIModel
+	runtimes        map[string]*RuntimeAPIModel
+	services        map[string]*ServiceAPIModel
+	networks        map[string]*NetworkAPIModel
+	kmsWallets      map[string]*KMSWalletAPIModel
+	kmsKeys         map[string]*KMSKeyAPIModel
+	cmsBuilds       map[string]*CMSBuildAPIModel
+	cmsActions      map[string]CMSActionAPIBaseAccessor
+	amsTasks        map[string]*AMSTaskAPIModel
+	amsTaskVersions map[string]map[string]interface{}
+	amsFFListeners  map[string]*AMSFFListenerAPIModel
+	ffsNode         *FireFlyStatusNodeAPIModel
+	ffsOrg          *FireFlyStatusOrgAPIModel
+	calls           []string
 }
 
 func startMockPlatformServer(t *testing.T) *mockPlatform {
 	mp := &mockPlatform{
-		t:              t,
-		environments:   make(map[string]*EnvironmentAPIModel),
-		runtimes:       make(map[string]*RuntimeAPIModel),
-		services:       make(map[string]*ServiceAPIModel),
-		networks:       make(map[string]*NetworkAPIModel),
-		kmsWallets:     make(map[string]*KMSWalletAPIModel),
-		kmsKeys:        make(map[string]*KMSKeyAPIModel),
-		cmsBuilds:      make(map[string]*CMSBuildAPIModel),
-		cmsActions:     make(map[string]CMSActionAPIBaseAccessor),
-		amsTasks:       make(map[string]*AMSTaskAPIModel),
-		amsFFListeners: make(map[string]*AMSFFListenerAPIModel),
-		router:         mux.NewRouter(),
-		calls:          []string{},
+		t:               t,
+		environments:    make(map[string]*EnvironmentAPIModel),
+		runtimes:        make(map[string]*RuntimeAPIModel),
+		services:        make(map[string]*ServiceAPIModel),
+		networks:        make(map[string]*NetworkAPIModel),
+		kmsWallets:      make(map[string]*KMSWalletAPIModel),
+		kmsKeys:         make(map[string]*KMSKeyAPIModel),
+		cmsBuilds:       make(map[string]*CMSBuildAPIModel),
+		cmsActions:      make(map[string]CMSActionAPIBaseAccessor),
+		amsTasks:        make(map[string]*AMSTaskAPIModel),
+		amsTaskVersions: make(map[string]map[string]interface{}),
+		amsFFListeners:  make(map[string]*AMSFFListenerAPIModel),
+		router:          mux.NewRouter(),
+		calls:           []string{},
 	}
 	// See environment_test.go
 	mp.register("/api/v1/environments", http.MethodPost, mp.postEnvironment)
@@ -118,6 +120,8 @@ func startMockPlatformServer(t *testing.T) *mockPlatform {
 	// See ams_task.go
 	mp.register("/endpoint/{env}/{service}/rest/api/v1/tasks/{task}", http.MethodGet, mp.getAMSTask)
 	mp.register("/endpoint/{env}/{service}/rest/api/v1/tasks/{task}", http.MethodPut, mp.putAMSTask)
+	mp.register("/endpoint/{env}/{service}/rest/api/v1/tasks/{task}/versions", http.MethodPost, mp.postAMSTaskVersion)
+	mp.register("/endpoint/{env}/{service}/rest/api/v1/tasks/{task}", http.MethodPatch, mp.patchAMSTask)
 	mp.register("/endpoint/{env}/{service}/rest/api/v1/tasks/{task}", http.MethodDelete, mp.deleteAMSTask)
 
 	// See ams_fflistener.go


### PR DESCRIPTION
Currently we push everything into the `task_yaml` on a task definition, and let the Kaleido API do the heavy lifting reconciling a new version each time. This is problematic as:
- You can't have a separate `description` for the Task and each Version
- You can't specify an `exampleInput`

Instead this PR changes things so the `name` and `description` move to the top-level task, and the `task_yaml` is just the version part.

You still get the automatic bumping of versions with this.