### PR TITLE
updated to just be KBI addition

### DIFF
--- a/examples/platform_stack/main.tf
+++ b/examples/platform_stack/main.tf
@@ -187,6 +187,31 @@ resource "kaleido_platform_service" "cms_0" {
   config_json = jsonencode({})
 }
 
+resource "kaleido_platform_runtime" "bir_0"{
+  type = "BlockIndexer"
+  name = "block_indexer"
+  environment = kaleido_platform_environment.env_0.id
+  config_json = jsonencode({})
+}
+
+resource "kaleido_platform_service" "bis_0"{
+  type = "BlockIndexer"
+  name = "block_indexer"
+  environment = kaleido_platform_environment.env_0.id
+  runtime = kaleido_platform_runtime.bir_0.id
+  config_json=jsonencode(
+    {
+      contractManager = {
+        id = kaleido_platform_service.cms_0.id
+      }
+      evmGateway = {
+        id = kaleido_platform_service.gws_0.id
+      }
+    }
+  )
+  hostnames = {"${kaleido_platform_network.net_0.name}" = ["ui", "rest"]}
+}
+
 resource "kaleido_platform_runtime" "amr_0" {
   type = "AssetManager"
   name = "asset_manager1"

--- a/examples/platform_stack_multiparty_sandbox/main.tf
+++ b/examples/platform_stack_multiparty_sandbox/main.tf
@@ -17,9 +17,9 @@ resource "kaleido_platform_environment" "env_0" {
   name = var.environment_name
 }
 
-resource "kaleido_platform_network" "net_besu" {
+resource "kaleido_platform_network" "net_0" {
   type = "Besu"
-  name = "${var.environment_name}_chain"
+  name = "evmchain1"
   environment = kaleido_platform_environment.env_0.id
   config_json = jsonencode({
     bootstrapOptions = {
@@ -46,7 +46,7 @@ resource "kaleido_platform_service" "bns" {
   runtime = kaleido_platform_runtime.bnr[count.index].id
   config_json = jsonencode({
     network = {
-      id = kaleido_platform_network.net_besu.id
+      id = kaleido_platform_network.net_0.id
     }
   })
   count = var.besu_node_count
@@ -93,7 +93,7 @@ resource "kaleido_platform_service" "gws_0" {
   runtime = kaleido_platform_runtime.gwr_0.id
   config_json = jsonencode({
     network = {
-      id =  kaleido_platform_network.net_besu.id
+      id =  kaleido_platform_network.net_0.id
     }
   })
 }
@@ -235,6 +235,31 @@ resource "kaleido_platform_service" "cms_0" {
   environment = kaleido_platform_environment.env_0.id
   runtime = kaleido_platform_runtime.cmr_0.id
   config_json = jsonencode({})
+}
+
+resource "kaleido_platform_runtime" "bir_0"{
+  type = "BlockIndexer"
+  name = "block_indexer"
+  environment = kaleido_platform_environment.env_0.id
+  config_json = jsonencode({})
+}
+
+resource "kaleido_platform_service" "bis_0"{
+  type = "BlockIndexer"
+  name = "block_indexer"
+  environment = kaleido_platform_environment.env_0.id
+  runtime = kaleido_platform_runtime.bir_0.id
+  config_json=jsonencode(
+    {
+      contractManager = {
+        id = kaleido_platform_service.cms_0.id
+      }
+      evmGateway = {
+        id = kaleido_platform_service.gws_0.id
+      }
+    }
+  )
+  hostnames = {"${kaleido_platform_network.net_0.name}" = ["ui", "rest"]}
 }
 
 resource "kaleido_platform_cms_build" "firefly_batch_pin" {


### PR DESCRIPTION
removed signer vs non-signer node types for now until EVM gateway updates. This change just simply adds KBI to both the platform_stack and multiparty_platform_stack examples