### PR TITLE
Add type for data model listeners

### DIFF
--- a/examples/platform_stack/main.tf
+++ b/examples/platform_stack/main.tf
@@ -285,7 +285,7 @@ resource "kaleido_platform_cms_action_deploy" "demotoken_erc721" {
   depends_on = [ data.kaleido_platform_evm_netinfo.gws_0 ]
 }
 
-resource "kaleido_platform_cms_action_creatapi" "erc20" {
+resource "kaleido_platform_cms_action_createapi" "erc20" {
   environment = kaleido_platform_environment.env_0.id
   service = kaleido_platform_service.cms_0.id
   build = kaleido_platform_cms_build.erc20.id
@@ -295,7 +295,7 @@ resource "kaleido_platform_cms_action_creatapi" "erc20" {
   depends_on = [ data.kaleido_platform_evm_netinfo.gws_0 ]
 }
 
-resource "kaleido_platform_cms_action_creatapi" "erc721" {
+resource "kaleido_platform_cms_action_createapi" "erc721" {
   environment = kaleido_platform_environment.env_0.id
   service = kaleido_platform_service.cms_0.id
   build = kaleido_platform_cms_build.erc721.id

--- a/kaleido/platform/ams_dmlistener.go
+++ b/kaleido/platform/ams_dmlistener.go
@@ -42,7 +42,7 @@ type AMSDMListenerAPIModel struct {
 	Created     string `json:"created,omitempty"`
 	Updated     string `json:"updated,omitempty"`
 	TaskID      string `json:"taskId,omitempty"`
-	TopicFilter string `tfsdk:"topicFilter"`
+	TopicFilter string `json:"topicFilter"`
 }
 
 func AMSDMListenerResourceFactory() resource.Resource {

--- a/kaleido/platform/ams_dmlistener.go
+++ b/kaleido/platform/ams_dmlistener.go
@@ -33,8 +33,6 @@ type AMSDMListenerResourceModel struct {
 	Service     types.String `tfsdk:"service"`
 	Name        types.String `tfsdk:"name"`
 	TaskID      types.String `tfsdk:"task_id"`
-	TaskName    types.String `tfsdk:"task_name"`
-	TaskVersion types.String `tfsdk:"task_version"`
 	TopicFilter types.String `tfsdk:"topic_filter"`
 }
 
@@ -44,8 +42,6 @@ type AMSDMListenerAPIModel struct {
 	Created     string `json:"created,omitempty"`
 	Updated     string `json:"updated,omitempty"`
 	TaskID      string `json:"taskId,omitempty"`
-	TaskName    string `json:"taskName,omitempty"`
-	TaskVersion string `json:"taskVersion,omitempty"`
 	TopicFilter string `tfsdk:"topicFilter"`
 }
 
@@ -80,13 +76,7 @@ func (r *ams_dmlistenerResource) Schema(_ context.Context, _ resource.SchemaRequ
 				Required: true,
 			},
 			"task_id": &schema.StringAttribute{
-				Optional: true,
-			},
-			"task_name": &schema.StringAttribute{
-				Optional: true,
-			},
-			"task_version": &schema.StringAttribute{
-				Optional: true,
+				Required: true,
 			},
 			"topic_filter": &schema.StringAttribute{
 				Optional: true,
@@ -97,15 +87,7 @@ func (r *ams_dmlistenerResource) Schema(_ context.Context, _ resource.SchemaRequ
 
 func (data *AMSDMListenerResourceModel) toAPI(api *AMSDMListenerAPIModel, diagnostics *diag.Diagnostics) bool {
 	api.Name = data.Name.ValueString()
-	if !data.TaskID.IsNull() {
-		api.TaskID = data.TaskID.ValueString()
-	}
-	if !data.TaskName.IsNull() {
-		api.TaskName = data.TaskName.ValueString()
-	}
-	if !data.TaskVersion.IsNull() {
-		api.TaskVersion = data.TaskVersion.ValueString()
-	}
+	api.TaskID = data.TaskID.ValueString()
 	if !data.TopicFilter.IsNull() {
 		api.TopicFilter = data.TopicFilter.ValueString()
 	}
@@ -115,9 +97,9 @@ func (data *AMSDMListenerResourceModel) toAPI(api *AMSDMListenerAPIModel, diagno
 func (api *AMSDMListenerAPIModel) toData(data *AMSDMListenerResourceModel) {
 	data.ID = types.StringValue(api.ID)
 	data.TaskID = types.StringValue(api.TaskID)
-	data.TaskName = types.StringValue(api.TaskName)
-	data.TaskVersion = types.StringValue(api.TaskVersion)
-	data.TopicFilter = types.StringValue(api.TopicFilter)
+	if api.TopicFilter != "" {
+		data.TopicFilter = types.StringValue(api.TopicFilter)
+	}
 }
 
 func (r *ams_dmlistenerResource) apiPath(data *AMSDMListenerResourceModel, idOrName string) string {

--- a/kaleido/platform/ams_dmlistener.go
+++ b/kaleido/platform/ams_dmlistener.go
@@ -1,0 +1,191 @@
+// Copyright © Kaleido, Inc. 2024
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package platform
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+type AMSDMListenerResourceModel struct {
+	ID          types.String `tfsdk:"id"`
+	Environment types.String `tfsdk:"environment"`
+	Service     types.String `tfsdk:"service"`
+	Name        types.String `tfsdk:"name"`
+	TaskID      types.String `tfsdk:"task_id"`
+	TaskName    types.String `tfsdk:"task_name"`
+	TaskVersion types.String `tfsdk:"task_version"`
+	TopicFilter types.String `tfsdk:"topic_filter"`
+}
+
+type AMSDMListenerAPIModel struct {
+	ID          string `json:"id,omitempty"`
+	Name        string `json:"name,omitempty"`
+	Created     string `json:"created,omitempty"`
+	Updated     string `json:"updated,omitempty"`
+	TaskID      string `json:"taskId,omitempty"`
+	TaskName    string `json:"taskName,omitempty"`
+	TaskVersion string `json:"taskVersion,omitempty"`
+	TopicFilter string `tfsdk:"topicFilter"`
+}
+
+func AMSDMListenerResourceFactory() resource.Resource {
+	return &ams_dmlistenerResource{}
+}
+
+type ams_dmlistenerResource struct {
+	commonResource
+}
+
+func (r *ams_dmlistenerResource) Metadata(_ context.Context, _ resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = "kaleido_platform_ams_dmlistener"
+}
+
+func (r *ams_dmlistenerResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"id": &schema.StringAttribute{
+				Computed:      true,
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+			},
+			"environment": &schema.StringAttribute{
+				Required:      true,
+				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
+			},
+			"service": &schema.StringAttribute{
+				Required:      true,
+				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
+			},
+			"name": &schema.StringAttribute{
+				Required: true,
+			},
+			"task_id": &schema.StringAttribute{
+				Optional: true,
+			},
+			"task_name": &schema.StringAttribute{
+				Optional: true,
+			},
+			"task_version": &schema.StringAttribute{
+				Optional: true,
+			},
+			"topic_filter": &schema.StringAttribute{
+				Optional: true,
+			},
+		},
+	}
+}
+
+func (data *AMSDMListenerResourceModel) toAPI(api *AMSDMListenerAPIModel, diagnostics *diag.Diagnostics) bool {
+	api.Name = data.Name.ValueString()
+	if !data.TaskID.IsNull() {
+		api.TaskID = data.TaskID.ValueString()
+	}
+	if !data.TaskName.IsNull() {
+		api.TaskName = data.TaskName.ValueString()
+	}
+	if !data.TaskVersion.IsNull() {
+		api.TaskVersion = data.TaskVersion.ValueString()
+	}
+	if !data.TopicFilter.IsNull() {
+		api.TopicFilter = data.TopicFilter.ValueString()
+	}
+	return true
+}
+
+func (api *AMSDMListenerAPIModel) toData(data *AMSDMListenerResourceModel) {
+	data.ID = types.StringValue(api.ID)
+	data.TaskID = types.StringValue(api.TaskID)
+	data.TaskName = types.StringValue(api.TaskName)
+	data.TaskVersion = types.StringValue(api.TaskVersion)
+	data.TopicFilter = types.StringValue(api.TopicFilter)
+}
+
+func (r *ams_dmlistenerResource) apiPath(data *AMSDMListenerResourceModel, idOrName string) string {
+	return fmt.Sprintf("/endpoint/%s/%s/rest/api/v1/listeners/datamodel/%s", data.Environment.ValueString(), data.Service.ValueString(), idOrName)
+}
+
+func (r *ams_dmlistenerResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+
+	var data AMSDMListenerResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+
+	var api AMSDMListenerAPIModel
+	ok := data.toAPI(&api, &resp.Diagnostics)
+	if ok {
+		ok, _ = r.apiRequest(ctx, http.MethodPut, r.apiPath(&data, data.Name.ValueString()), &api, &api, &resp.Diagnostics)
+	}
+	if !ok {
+		return
+	}
+
+	api.toData(&data)
+	resp.Diagnostics.Append(resp.State.Set(ctx, data)...)
+
+}
+
+func (r *ams_dmlistenerResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+
+	var data AMSDMListenerResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	resp.Diagnostics.Append(req.State.GetAttribute(ctx, path.Root("id"), &data.ID)...)
+
+	var api AMSDMListenerAPIModel
+	ok := data.toAPI(&api, &resp.Diagnostics)
+	if ok {
+		ok, _ = r.apiRequest(ctx, http.MethodPut, r.apiPath(&data, data.ID.ValueString()), &api, &api, &resp.Diagnostics)
+	}
+	if !ok {
+		return
+	}
+
+	api.toData(&data)
+	resp.Diagnostics.Append(resp.State.Set(ctx, data)...)
+}
+
+func (r *ams_dmlistenerResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var data AMSDMListenerResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+
+	var api AMSDMListenerAPIModel
+	api.ID = data.ID.ValueString()
+	ok, status := r.apiRequest(ctx, http.MethodGet, r.apiPath(&data, data.ID.ValueString()), nil, &api, &resp.Diagnostics, Allow404())
+	if !ok {
+		return
+	}
+	if status == 404 {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
+	api.toData(&data)
+	resp.Diagnostics.Append(resp.State.Set(ctx, data)...)
+}
+
+func (r *ams_dmlistenerResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var data AMSDMListenerResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+
+	_, _ = r.apiRequest(ctx, http.MethodDelete, r.apiPath(&data, data.ID.ValueString()), nil, nil, &resp.Diagnostics, Allow404())
+
+	r.waitForRemoval(ctx, r.apiPath(&data, data.ID.ValueString()), &resp.Diagnostics)
+}

--- a/kaleido/platform/ams_dmlistener_test.go
+++ b/kaleido/platform/ams_dmlistener_test.go
@@ -1,0 +1,100 @@
+// Copyright © Kaleido, Inc. 2024
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package platform
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/aidarkhanov/nanoid"
+	"github.com/gorilla/mux"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/stretchr/testify/assert"
+
+	_ "embed"
+)
+
+var ams_dmlistenerStep1 = `
+resource "kaleido_platform_ams_dmlistener" "ams_dmlistener1" {
+    environment = "env1"
+	service = "service1"
+	name = "listener1"
+	task_id = "task1"
+	topic_filter = "trigger-.*"
+}
+`
+
+func TestAMSDMListener1(t *testing.T) {
+
+	mp, providerConfig := testSetup(t)
+	defer func() {
+		mp.checkClearCalls([]string{
+			"PUT /endpoint/{env}/{service}/rest/api/v1/listeners/datamodel/{listener}", // by name initially
+			"GET /endpoint/{env}/{service}/rest/api/v1/listeners/datamodel/{listener}",
+			"DELETE /endpoint/{env}/{service}/rest/api/v1/listeners/datamodel/{listener}",
+			"GET /endpoint/{env}/{service}/rest/api/v1/listeners/datamodel/{listener}",
+		})
+		mp.server.Close()
+	}()
+
+	ams_dmlistener1Resource := "kaleido_platform_ams_dmlistener.ams_dmlistener1"
+	resource.Test(t, resource.TestCase{
+		IsUnitTest:               true,
+		ProtoV6ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: providerConfig + ams_dmlistenerStep1,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet(ams_dmlistener1Resource, "id"),
+				),
+			},
+		},
+	})
+}
+
+func (mp *mockPlatform) getAMSDMListener(res http.ResponseWriter, req *http.Request) {
+	obj := mp.amsDMListeners[mux.Vars(req)["env"]+"/"+mux.Vars(req)["service"]+"/"+mux.Vars(req)["listener"]]
+	if obj == nil {
+		mp.respond(res, nil, 404)
+	} else {
+		mp.respond(res, obj, 200)
+	}
+}
+
+func (mp *mockPlatform) putAMSDMListener(res http.ResponseWriter, req *http.Request) {
+	now := time.Now().UTC()
+	obj := mp.amsDMListeners[mux.Vars(req)["env"]+"/"+mux.Vars(req)["service"]+"/"+mux.Vars(req)["listener"]] // expected behavior of provider is PUT only on exists
+	var newObj AMSDMListenerAPIModel
+	mp.getBody(req, &newObj)
+	if obj == nil {
+		assert.Equal(mp.t, newObj.Name, mux.Vars(req)["listener"])
+		newObj.ID = nanoid.New()
+		newObj.Created = now.Format(time.RFC3339Nano)
+	} else {
+		assert.Equal(mp.t, obj.ID, mux.Vars(req)["listener"])
+		newObj.ID = mux.Vars(req)["listener"]
+		newObj.Created = obj.Created
+	}
+	newObj.Updated = now.Format(time.RFC3339Nano)
+	mp.amsDMListeners[mux.Vars(req)["env"]+"/"+mux.Vars(req)["service"]+"/"+newObj.ID] = &newObj
+	mp.respond(res, &newObj, 200)
+}
+
+func (mp *mockPlatform) deleteAMSDMListener(res http.ResponseWriter, req *http.Request) {
+	obj := mp.amsDMListeners[mux.Vars(req)["env"]+"/"+mux.Vars(req)["service"]+"/"+mux.Vars(req)["listener"]]
+	assert.NotNil(mp.t, obj)
+	delete(mp.amsDMListeners, mux.Vars(req)["env"]+"/"+mux.Vars(req)["service"]+"/"+mux.Vars(req)["listener"])
+	mp.respond(res, nil, 204)
+}

--- a/kaleido/platform/cms_action_create_api.go
+++ b/kaleido/platform/cms_action_create_api.go
@@ -65,14 +65,14 @@ type CMSActionCreateAPIBuildInputAPIModel struct {
 }
 
 func CMSActionCreateAPIResourceFactory() resource.Resource {
-	return &cms_action_creatapiResource{}
+	return &cms_action_createapiResource{}
 }
 
 func (data *CMSActionCreateAPIResourceModel) ResourceIdentifiers() (types.String, types.String, types.String) {
 	return data.Environment, data.Service, data.ID
 }
 
-type cms_action_creatapiResource struct {
+type cms_action_createapiResource struct {
 	cms_action_baseResource
 }
 
@@ -83,11 +83,11 @@ func (a *CMSActionCreateAPIAPIModel) OutputBase() *CMSActionOutputBaseAPIModel {
 	return &a.Output.CMSActionOutputBaseAPIModel
 }
 
-func (r *cms_action_creatapiResource) Metadata(_ context.Context, _ resource.MetadataRequest, resp *resource.MetadataResponse) {
-	resp.TypeName = "kaleido_platform_cms_action_creatapi"
+func (r *cms_action_createapiResource) Metadata(_ context.Context, _ resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = "kaleido_platform_cms_action_createapi"
 }
 
-func (r *cms_action_creatapiResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+func (r *cms_action_createapiResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
 			"id": &schema.StringAttribute{
@@ -156,7 +156,7 @@ func (api *CMSActionCreateAPIAPIModel) toData(data *CMSActionCreateAPIResourceMo
 	}
 }
 
-func (r *cms_action_creatapiResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+func (r *cms_action_createapiResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 
 	var data CMSActionCreateAPIResourceModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
@@ -175,7 +175,7 @@ func (r *cms_action_creatapiResource) Create(ctx context.Context, req resource.C
 
 }
 
-func (r *cms_action_creatapiResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+func (r *cms_action_createapiResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
 
 	var data CMSActionCreateAPIResourceModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
@@ -192,7 +192,7 @@ func (r *cms_action_creatapiResource) Update(ctx context.Context, req resource.U
 	resp.Diagnostics.Append(resp.State.Set(ctx, data)...)
 }
 
-func (r *cms_action_creatapiResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+func (r *cms_action_createapiResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
 	var data CMSActionCreateAPIResourceModel
 	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
 
@@ -211,7 +211,7 @@ func (r *cms_action_creatapiResource) Read(ctx context.Context, req resource.Rea
 	resp.Diagnostics.Append(resp.State.Set(ctx, data)...)
 }
 
-func (r *cms_action_creatapiResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+func (r *cms_action_createapiResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
 	var data CMSActionCreateAPIResourceModel
 	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
 

--- a/kaleido/platform/cms_action_create_api_test.go
+++ b/kaleido/platform/cms_action_create_api_test.go
@@ -24,8 +24,8 @@ import (
 	_ "embed"
 )
 
-var cms_action_creatapiStep1 = `
-resource "kaleido_platform_cms_action_creatapi" "cms_action_creatapi1" {
+var cms_action_createapiStep1 = `
+resource "kaleido_platform_cms_action_createapi" "cms_action_createapi1" {
     environment = "env1"
 	service = "service1"
 	build = "build1"
@@ -36,8 +36,8 @@ resource "kaleido_platform_cms_action_creatapi" "cms_action_creatapi1" {
 }
 `
 
-var cms_action_creatapiStep2 = `
-resource "kaleido_platform_cms_action_creatapi" "cms_action_creatapi1" {
+var cms_action_createapiStep2 = `
+resource "kaleido_platform_cms_action_createapi" "cms_action_createapi1" {
     environment = "env1"
 	service = "service1"
 	build = "build1"
@@ -67,29 +67,29 @@ func TestCMSActionCreateAPI1(t *testing.T) {
 		mp.server.Close()
 	}()
 
-	cms_action_creatapi1Resource := "kaleido_platform_cms_action_creatapi.cms_action_creatapi1"
+	cms_action_createapi1Resource := "kaleido_platform_cms_action_createapi.cms_action_createapi1"
 	resource.Test(t, resource.TestCase{
 		IsUnitTest:               true,
 		ProtoV6ProviderFactories: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: providerConfig + cms_action_creatapiStep1,
+				Config: providerConfig + cms_action_createapiStep1,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttrSet(cms_action_creatapi1Resource, "id"),
-					resource.TestCheckResourceAttr(cms_action_creatapi1Resource, "name", `api1`),
-					resource.TestCheckResourceAttr(cms_action_creatapi1Resource, "firefly_namespace", `ns1`),
+					resource.TestCheckResourceAttrSet(cms_action_createapi1Resource, "id"),
+					resource.TestCheckResourceAttr(cms_action_createapi1Resource, "name", `api1`),
+					resource.TestCheckResourceAttr(cms_action_createapi1Resource, "firefly_namespace", `ns1`),
 				),
 			},
 			{
-				Config: providerConfig + cms_action_creatapiStep2,
+				Config: providerConfig + cms_action_createapiStep2,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttrSet(cms_action_creatapi1Resource, "id"),
-					resource.TestCheckResourceAttr(cms_action_creatapi1Resource, "name", `api1`),
-					resource.TestCheckResourceAttr(cms_action_creatapi1Resource, "firefly_namespace", `ns1`),
-					resource.TestCheckResourceAttr(cms_action_creatapi1Resource, "description", `create an API for a thing`),
+					resource.TestCheckResourceAttrSet(cms_action_createapi1Resource, "id"),
+					resource.TestCheckResourceAttr(cms_action_createapi1Resource, "name", `api1`),
+					resource.TestCheckResourceAttr(cms_action_createapi1Resource, "firefly_namespace", `ns1`),
+					resource.TestCheckResourceAttr(cms_action_createapi1Resource, "description", `create an API for a thing`),
 					func(s *terraform.State) error {
 						// Compare the final result on the mock-server side
-						id := s.RootModule().Resources[cms_action_creatapi1Resource].Primary.Attributes["id"]
+						id := s.RootModule().Resources[cms_action_createapi1Resource].Primary.Attributes["id"]
 						obj := mp.cmsActions[fmt.Sprintf("env1/service1/%s", id)].((*CMSActionCreateAPIAPIModel))
 						testJSONEqual(t, obj, fmt.Sprintf(`
 						{

--- a/kaleido/platform/common.go
+++ b/kaleido/platform/common.go
@@ -241,6 +241,7 @@ func Resources() []func() resource.Resource {
 		CMSActionCreateAPIResourceFactory,
 		AMSTaskResourceFactory,
 		AMSFFListenerResourceFactory,
+		AMSDMListenerResourceFactory,
 		FireFlyRegistrationResourceFactory,
 	}
 }

--- a/kaleido/platform/mockserver_test.go
+++ b/kaleido/platform/mockserver_test.go
@@ -47,6 +47,7 @@ type mockPlatform struct {
 	amsTasks        map[string]*AMSTaskAPIModel
 	amsTaskVersions map[string]map[string]interface{}
 	amsFFListeners  map[string]*AMSFFListenerAPIModel
+	amsDMListeners  map[string]*AMSDMListenerAPIModel
 	ffsNode         *FireFlyStatusNodeAPIModel
 	ffsOrg          *FireFlyStatusOrgAPIModel
 	calls           []string
@@ -66,6 +67,7 @@ func startMockPlatformServer(t *testing.T) *mockPlatform {
 		amsTasks:        make(map[string]*AMSTaskAPIModel),
 		amsTaskVersions: make(map[string]map[string]interface{}),
 		amsFFListeners:  make(map[string]*AMSFFListenerAPIModel),
+		amsDMListeners:  make(map[string]*AMSDMListenerAPIModel),
 		router:          mux.NewRouter(),
 		calls:           []string{},
 	}
@@ -128,6 +130,11 @@ func startMockPlatformServer(t *testing.T) *mockPlatform {
 	mp.register("/endpoint/{env}/{service}/rest/api/v1/listeners/firefly/{listener}", http.MethodGet, mp.getAMSFFListener)
 	mp.register("/endpoint/{env}/{service}/rest/api/v1/listeners/firefly/{listener}", http.MethodPut, mp.putAMSFFListener)
 	mp.register("/endpoint/{env}/{service}/rest/api/v1/listeners/firefly/{listener}", http.MethodDelete, mp.deleteAMSFFListener)
+
+	// See ams_dmlistener.go
+	mp.register("/endpoint/{env}/{service}/rest/api/v1/listeners/datamodel/{listener}", http.MethodGet, mp.getAMSDMListener)
+	mp.register("/endpoint/{env}/{service}/rest/api/v1/listeners/datamodel/{listener}", http.MethodPut, mp.putAMSDMListener)
+	mp.register("/endpoint/{env}/{service}/rest/api/v1/listeners/datamodel/{listener}", http.MethodDelete, mp.deleteAMSDMListener)
 
 	// See firefly_registration.go
 	mp.register("/endpoint/{env}/{service}/rest/api/v1/network/nodes/self", http.MethodPost, mp.postFireFlyRegistrationNode)


### PR DESCRIPTION
Note: unit tests are currently broken as of https://github.com/kaleido-io/terraform-provider-kaleido/pull/65 (and they don't run on PRs or on the branch)