### PR TITLE
Fix group test

### DIFF
--- a/kaleido/platform/group_test.go
+++ b/kaleido/platform/group_test.go
@@ -77,7 +77,7 @@ func TestGroup1(t *testing.T) {
 					func(s *terraform.State) error {
 						// Compare the final result on the mock-server side
 						id := s.RootModule().Resources[group1Resource].Primary.Attributes["id"]
-						rt := mp.group[id]
+						rt := mp.groups[id]
 						testJSONEqual(t, rt, fmt.Sprintf(`
 						{
 							"id": "%[1]s",
@@ -100,7 +100,7 @@ func TestGroup1(t *testing.T) {
 }
 
 func (mp *mockPlatform) getGroup(res http.ResponseWriter, req *http.Request) {
-	rt := mp.group[mux.Vars(req)["group"]]
+	rt := mp.groups[mux.Vars(req)["group"]]
 	if rt == nil {
 		mp.respond(res, nil, 404)
 	} else {
@@ -115,27 +115,27 @@ func (mp *mockPlatform) postGroup(res http.ResponseWriter, req *http.Request) {
 	now := time.Now().UTC()
 	rt.Created = &now
 	rt.Updated = &now
-	mp.group[rt.ID] = &rt
+	mp.groups[rt.ID] = &rt
 	mp.respond(res, &rt, 201)
 }
 
 func (mp *mockPlatform) patchGroup(res http.ResponseWriter, req *http.Request) {
-	rt := mp.group[mux.Vars(req)["group"]] // expected behavior of provider is PATCH only on exists
+	rt := mp.groups[mux.Vars(req)["group"]] // expected behavior of provider is PATCH only on exists
 	assert.NotNil(mp.t, rt)
-	var newRT EnvironmentAPIModel
+	var newRT GroupAPIModel
 	mp.getBody(req, &newRT)
-	assert.Equal(mp.t, rt.ID, newRT.ID)             // expected behavior of provider
+	assert.Equal(mp.t, rt.ID, newRT.ID)               // expected behavior of provider
 	assert.Equal(mp.t, rt.ID, mux.Vars(req)["group"]) // expected behavior of provider
 	now := time.Now().UTC()
 	newRT.Created = rt.Created
 	newRT.Updated = &now
-	mp.environments[mux.Vars(req)["group"]] = &newRT
+	mp.groups[mux.Vars(req)["group"]] = &newRT
 	mp.respond(res, &newRT, 200)
 }
 
 func (mp *mockPlatform) deleteGroup(res http.ResponseWriter, req *http.Request) {
-	rt := mp.group[mux.Vars(req)["group"]]
+	rt := mp.groups[mux.Vars(req)["group"]]
 	assert.NotNil(mp.t, rt)
-	delete(mp.environments, mux.Vars(req)["group"])
+	delete(mp.groups, mux.Vars(req)["group"])
 	mp.respond(res, nil, 204)
 }

--- a/kaleido/platform/mockserver_test.go
+++ b/kaleido/platform/mockserver_test.go
@@ -48,6 +48,7 @@ type mockPlatform struct {
 	amsTaskVersions map[string]map[string]interface{}
 	amsFFListeners  map[string]*AMSFFListenerAPIModel
 	amsDMListeners  map[string]*AMSDMListenerAPIModel
+	groups          map[string]*GroupAPIModel
 	ffsNode         *FireFlyStatusNodeAPIModel
 	ffsOrg          *FireFlyStatusOrgAPIModel
 	calls           []string
@@ -68,6 +69,7 @@ func startMockPlatformServer(t *testing.T) *mockPlatform {
 		amsTaskVersions: make(map[string]map[string]interface{}),
 		amsFFListeners:  make(map[string]*AMSFFListenerAPIModel),
 		amsDMListeners:  make(map[string]*AMSDMListenerAPIModel),
+		groups:          make(map[string]*GroupAPIModel),
 		router:          mux.NewRouter(),
 		calls:           []string{},
 	}
@@ -140,6 +142,12 @@ func startMockPlatformServer(t *testing.T) *mockPlatform {
 	mp.register("/endpoint/{env}/{service}/rest/api/v1/network/nodes/self", http.MethodPost, mp.postFireFlyRegistrationNode)
 	mp.register("/endpoint/{env}/{service}/rest/api/v1/network/organizations/self", http.MethodPost, mp.postFireFlyRegistrationOrg)
 	mp.register("/endpoint/{env}/{service}/rest/api/v1/status", http.MethodGet, mp.getFireFlyStatus)
+
+	// See group_test.go
+	mp.register("/api/v1/groups", http.MethodPost, mp.postGroup)
+	mp.register("/api/v1/groups/{group}", http.MethodGet, mp.getGroup)
+	mp.register("/api/v1/groups/{group}", http.MethodPatch, mp.patchGroup)
+	mp.register("/api/v1/groups/{group}", http.MethodDelete, mp.deleteGroup)
 
 	mp.server = httptest.NewServer(mp.router)
 	return mp

--- a/kaleido/platform/service_access.go
+++ b/kaleido/platform/service_access.go
@@ -18,7 +18,6 @@ import (
 	"net/http"
 	"time"
 
-	// "github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
@@ -27,17 +26,17 @@ import (
 )
 
 type ServiceAccessResourceModel struct {
-	ID   types.String `tfsdk:"id"`
-	groupid   types.String `tfsdk:"id"`
-	serviceid types.String `tfsdk:"id"`
+	ID        types.String `tfsdk:"id"`
+	GroupID   types.String `tfsdk:"groupid"`
+	ServiceID types.String `tfsdk:"serviceid"`
 }
 
 type ServiceAccessAPIModel struct {
-	ID      string     `json:"id,omitempty"`
-	groupid      string     `json:"id,omitempty"`
-	Created *time.Time `json:"created,omitempty"`
-	Updated *time.Time `json:"updated,omitempty"`
-	serviceid    string     `json:"id,omitempty"`
+	ID        string     `json:"id,omitempty"`
+	GroupID   string     `json:"groupId,omitempty"`
+	Created   *time.Time `json:"created,omitempty"`
+	Updated   *time.Time `json:"updated,omitempty"`
+	ServiceID string     `json:"serviceId,omitempty"`
 }
 
 func ServiceAccessResourceFactory() resource.Resource {
@@ -70,8 +69,8 @@ func (r *serviceAccessResource) Schema(_ context.Context, _ resource.SchemaReque
 }
 
 func (data *ServiceAccessResourceModel) toAPI(api *ServiceAccessAPIModel) {
-	api.groupid = data.groupid.ValueString()
-	api.serviceid = data.serviceid.ValueString()
+	api.GroupID = data.GroupID.ValueString()
+	api.ServiceID = data.ServiceID.ValueString()
 }
 
 func (api *ServiceAccessAPIModel) toData(data *ServiceAccessResourceModel) {
@@ -103,7 +102,7 @@ func (r *serviceAccessResource) Create(ctx context.Context, req resource.CreateR
 
 }
 
-//update is useless right now - but uncommenting to work with the resource model
+// update is useless right now - but uncommenting to work with the resource model
 func (r *serviceAccessResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
 
 	// var data ServiceAccessResourceModel


### PR DESCRIPTION
This fixes the broken unit test added in https://github.com/kaleido-io/terraform-provider-kaleido/pull/65.

I have no idea if any of the functionality around groups/access is actually working now (judging from the code and the test, it was definitely broken before). This makes the test pass.