### PR TITLE
deploy to transaction manager

### DIFF
--- a/examples/platform_stack_multiparty_sandbox/main.tf
+++ b/examples/platform_stack_multiparty_sandbox/main.tf
@@ -191,25 +191,12 @@ resource "kaleido_platform_runtime" "ffr_0" {
   config_json = jsonencode({})
 }
 
-resource "kaleido_platform_service" "seed_firefly" {
-  type = "FireFly"
-  name = "seed"
-  environment = kaleido_platform_environment.env_0.id
-  runtime = kaleido_platform_runtime.ffr_0.id
-  config_json = jsonencode({
-    transactionManager = {
-      id = kaleido_platform_service.tms_0.id
-    }
-  })
-}
-
 resource "kaleido_platform_runtime" "pdr_0" {
   type = "PrivateDataManager"
   name = "data_manager"
   environment = kaleido_platform_environment.env_0.id
   config_json = jsonencode({})
 }
-
 
 resource "kaleido_platform_service" "pds_0" {
   type = "PrivateDataManager"
@@ -279,7 +266,7 @@ resource "kaleido_platform_cms_action_deploy" "firefly_batch_pin" {
   service = kaleido_platform_service.cms_0.id
   build = kaleido_platform_cms_build.firefly_batch_pin.id
   name = "firefly_batch_pin"
-  firefly_namespace = kaleido_platform_service.seed_firefly.name
+  transaction_manager = kaleido_platform_service.tms_0.id
   signing_key = kaleido_platform_kms_key.seed_key.address
   depends_on = [ data.kaleido_platform_evm_netinfo.gws_0 ]
 }

--- a/kaleido/platform/cms_action_base_test.go
+++ b/kaleido/platform/cms_action_base_test.go
@@ -65,7 +65,7 @@ func (mp *mockPlatform) postCMSAction(res http.ResponseWriter, req *http.Request
 	}
 	base = obj.ActionBase()
 	base.ID = nanoid.New()
-	now := time.Now()
+	now := time.Now().UTC()
 	base.Created = &now
 	base.Updated = &now
 	mp.cmsActions[mux.Vars(req)["env"]+"/"+mux.Vars(req)["service"]+"/"+base.ID] = obj

--- a/kaleido/platform/cms_action_deploy.go
+++ b/kaleido/platform/cms_action_deploy.go
@@ -28,20 +28,21 @@ import (
 )
 
 type CMSActionDeployResourceModel struct {
-	ID               types.String `tfsdk:"id"`
-	Environment      types.String `tfsdk:"environment"`
-	Service          types.String `tfsdk:"service"`
-	Build            types.String `tfsdk:"build"`
-	Name             types.String `tfsdk:"name"`
-	Description      types.String `tfsdk:"description"`
-	FireFlyNamespace types.String `tfsdk:"firefly_namespace"`
-	SigningKey       types.String `tfsdk:"signing_key"`
-	ParamsJSON       types.String `tfsdk:"params_json"`
-	TransactionID    types.String `tfsdk:"transaction_id"`
-	IdempotencyKey   types.String `tfsdk:"idempotency_key"`
-	OperationID      types.String `tfsdk:"operation_id"`
-	ContractAddress  types.String `tfsdk:"contract_address"`
-	BlockNumber      types.String `tfsdk:"block_number"`
+	ID                 types.String `tfsdk:"id"`
+	Environment        types.String `tfsdk:"environment"`
+	Service            types.String `tfsdk:"service"`
+	Build              types.String `tfsdk:"build"`
+	Name               types.String `tfsdk:"name"`
+	Description        types.String `tfsdk:"description"`
+	FireFlyNamespace   types.String `tfsdk:"firefly_namespace"`
+	TransactionManager types.String `tfsdk:"transaction_manager"`
+	SigningKey         types.String `tfsdk:"signing_key"`
+	ParamsJSON         types.String `tfsdk:"params_json"`
+	TransactionID      types.String `tfsdk:"transaction_id"`
+	IdempotencyKey     types.String `tfsdk:"idempotency_key"`
+	OperationID        types.String `tfsdk:"operation_id"`
+	ContractAddress    types.String `tfsdk:"contract_address"`
+	BlockNumber        types.String `tfsdk:"block_number"`
 }
 
 type CMSActionDeployAPIModel struct {
@@ -51,10 +52,11 @@ type CMSActionDeployAPIModel struct {
 }
 
 type CMSDeployActionInputAPIModel struct {
-	Namespace         string                             `json:"namespace,omitempty"`
-	Build             *CMSActionDeployBuildInputAPIModel `json:"build,omitempty"`
-	SingingKey        string                             `json:"signingKey,omitempty"`
-	ConstructorParams interface{}                        `json:"constructorParams,omitempty"`
+	Namespace          string                             `json:"namespace,omitempty"`
+	TransactionManager string                             `json:"transactionMgr,omitempty"`
+	Build              *CMSActionDeployBuildInputAPIModel `json:"build,omitempty"`
+	SingingKey         string                             `json:"signingKey,omitempty"`
+	ConstructorParams  interface{}                        `json:"constructorParams,omitempty"`
 }
 
 type CMSDeployActionOutputAPIModel struct {
@@ -119,7 +121,11 @@ func (r *cms_action_deployResource) Schema(_ context.Context, _ resource.SchemaR
 				Optional: true,
 			},
 			"firefly_namespace": &schema.StringAttribute{
-				Required:      true,
+				Optional:      true,
+				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
+			},
+			"transaction_manager": &schema.StringAttribute{
+				Optional:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"build": &schema.StringAttribute{
@@ -158,7 +164,8 @@ func (data *CMSActionDeployResourceModel) toAPI(api *CMSActionDeployAPIModel, di
 	api.Name = data.Name.ValueString()
 	api.Description = data.Description.ValueString()
 	api.Input = CMSDeployActionInputAPIModel{
-		Namespace: data.FireFlyNamespace.ValueString(),
+		Namespace:          data.FireFlyNamespace.ValueString(),
+		TransactionManager: data.TransactionManager.ValueString(),
 		Build: &CMSActionDeployBuildInputAPIModel{
 			ID: data.Build.ValueString(),
 		},


### PR DESCRIPTION
Contract manager is now able to deploy directly through transaction manager for cases where a firefly namespace is not available (or not available yet). e.g. when deploying the batch pin contract.  This PR updated the provider to exploit that new ability.