### PR TITLE
Provide utility resource to upsert data model

### DIFF
--- a/kaleido/platform/ams_dmlistener.go
+++ b/kaleido/platform/ams_dmlistener.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -85,7 +84,7 @@ func (r *ams_dmlistenerResource) Schema(_ context.Context, _ resource.SchemaRequ
 	}
 }
 
-func (data *AMSDMListenerResourceModel) toAPI(api *AMSDMListenerAPIModel, diagnostics *diag.Diagnostics) bool {
+func (data *AMSDMListenerResourceModel) toAPI(api *AMSDMListenerAPIModel) bool {
 	api.Name = data.Name.ValueString()
 	api.TaskID = data.TaskID.ValueString()
 	if !data.TopicFilter.IsNull() {
@@ -112,7 +111,7 @@ func (r *ams_dmlistenerResource) Create(ctx context.Context, req resource.Create
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
 
 	var api AMSDMListenerAPIModel
-	ok := data.toAPI(&api, &resp.Diagnostics)
+	ok := data.toAPI(&api)
 	if ok {
 		ok, _ = r.apiRequest(ctx, http.MethodPut, r.apiPath(&data, data.Name.ValueString()), &api, &api, &resp.Diagnostics)
 	}
@@ -132,7 +131,7 @@ func (r *ams_dmlistenerResource) Update(ctx context.Context, req resource.Update
 	resp.Diagnostics.Append(req.State.GetAttribute(ctx, path.Root("id"), &data.ID)...)
 
 	var api AMSDMListenerAPIModel
-	ok := data.toAPI(&api, &resp.Diagnostics)
+	ok := data.toAPI(&api)
 	if ok {
 		ok, _ = r.apiRequest(ctx, http.MethodPut, r.apiPath(&data, data.ID.ValueString()), &api, &api, &resp.Diagnostics)
 	}

--- a/kaleido/platform/ams_dmupsert.go
+++ b/kaleido/platform/ams_dmupsert.go
@@ -1,0 +1,114 @@
+// Copyright © Kaleido, Inc. 2024
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package platform
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"gopkg.in/yaml.v3"
+)
+
+type AMSDMUpsertResourceModel struct {
+	Environment    types.String `tfsdk:"environment"`
+	Service        types.String `tfsdk:"service"`
+	BulkUpsertYAML types.String `tfsdk:"bulk_upsert_yaml"`
+}
+
+func AMSDMUpsertResourceFactory() resource.Resource {
+	return &ams_dmupsertResource{}
+}
+
+type ams_dmupsertResource struct {
+	commonResource
+}
+
+func (r *ams_dmupsertResource) Metadata(_ context.Context, _ resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = "kaleido_platform_ams_dmupsert"
+}
+
+func (r *ams_dmupsertResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"environment": &schema.StringAttribute{
+				Required:      true,
+				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
+			},
+			"service": &schema.StringAttribute{
+				Required:      true,
+				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
+			},
+			"bulk_upsert_yaml": &schema.StringAttribute{
+				Required:    true,
+				Description: "This is a bulk upsert input payload in YAML/JSON",
+			},
+		},
+	}
+}
+
+func (data *AMSDMUpsertResourceModel) toAPI(diagnostics *diag.Diagnostics) map[string]interface{} {
+	var parsedYAML map[string]interface{}
+	err := yaml.Unmarshal([]byte(data.BulkUpsertYAML.ValueString()), &parsedYAML)
+	if err != nil {
+		diagnostics.AddError("invalid task YAML", err.Error())
+		return nil
+	}
+	return parsedYAML
+}
+
+func (r *ams_dmupsertResource) apiPath(data *AMSDMUpsertResourceModel) string {
+	return fmt.Sprintf("/endpoint/%s/%s/rest/api/v1/bulk/datamodel", data.Environment.ValueString(), data.Service.ValueString())
+}
+
+func (r *ams_dmupsertResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+
+	var data AMSDMUpsertResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+
+	parsedYAML := data.toAPI(&resp.Diagnostics)
+	if parsedYAML != nil {
+		_, _ = r.apiRequest(ctx, http.MethodPut, r.apiPath(&data), parsedYAML, nil, &resp.Diagnostics)
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, data)...)
+
+}
+
+func (r *ams_dmupsertResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+
+	var data AMSDMUpsertResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+
+	parsedYAML := data.toAPI(&resp.Diagnostics)
+	if parsedYAML != nil {
+		_, _ = r.apiRequest(ctx, http.MethodPut, r.apiPath(&data), parsedYAML, nil, &resp.Diagnostics)
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, data)...)
+}
+
+func (r *ams_dmupsertResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	// no-op
+}
+
+func (r *ams_dmupsertResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	// no-op
+}

--- a/kaleido/platform/ams_dmupsert_test.go
+++ b/kaleido/platform/ams_dmupsert_test.go
@@ -1,0 +1,109 @@
+// Copyright © Kaleido, Inc. 2024
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package platform
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/gorilla/mux"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+
+	_ "embed"
+)
+
+var ams_dmupsertStep1 = `
+resource "kaleido_platform_ams_dmupsert" "ams_dmupsert1" {
+    environment = "env1"
+	service = "service1"
+    bulk_upsert_yaml = yamlencode(
+		{
+			"addresses": [
+				{
+					"updateType": "create_or_replace",
+					"address": "0x93976AE88d24130979FE554bFdfF32008839b04B",
+					"displayName": "bob"
+				}
+			]
+		}
+    )
+}
+`
+
+var ams_dmupsertStep2 = `
+resource "kaleido_platform_ams_dmupsert" "ams_dmupsert1" {
+    environment = "env1"
+	service = "service1"
+    bulk_upsert_yaml = yamlencode(
+		{
+			"addresses": [
+				{
+					"updateType": "create_or_replace",
+					"address": "0x93976AE88d24130979FE554bFdfF32008839b04B",
+					"displayName": "sally"
+				}
+			]
+		}
+    )
+}
+`
+
+func TestAMSDMUpsert1(t *testing.T) {
+
+	mp, providerConfig := testSetup(t)
+	defer func() {
+		mp.checkClearCalls([]string{
+			"PUT /endpoint/{env}/{service}/rest/api/v1/bulk/datamodel",
+			"PUT /endpoint/{env}/{service}/rest/api/v1/bulk/datamodel",
+		})
+		mp.server.Close()
+	}()
+
+	resource.Test(t, resource.TestCase{
+		IsUnitTest:               true,
+		ProtoV6ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: providerConfig + ams_dmupsertStep1,
+			},
+			{
+				Config: providerConfig + ams_dmupsertStep2,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					func(s *terraform.State) error {
+						// Compare the final result on the mock-server side
+						obj := mp.amsDMUpserts["env1/service1"]
+						testYAMLEqual(t, obj, `{
+							"addresses": [
+								{
+									"updateType": "create_or_replace",
+									"address": "0x93976AE88d24130979FE554bFdfF32008839b04B",
+									"displayName": "sally"
+								}
+							]
+						}`)
+						return nil
+					},
+				),
+			},
+		},
+	})
+}
+
+func (mp *mockPlatform) putAMSDMUpsert(res http.ResponseWriter, req *http.Request) {
+	var newObj map[string]interface{}
+	mp.getBody(req, &newObj)
+	mp.amsDMUpserts[mux.Vars(req)["env"]+"/"+mux.Vars(req)["service"]] = newObj
+	mp.respond(res, &newObj, 200)
+}

--- a/kaleido/platform/common.go
+++ b/kaleido/platform/common.go
@@ -242,6 +242,7 @@ func Resources() []func() resource.Resource {
 		AMSTaskResourceFactory,
 		AMSFFListenerResourceFactory,
 		AMSDMListenerResourceFactory,
+		AMSDMUpsertResourceFactory,
 		FireFlyRegistrationResourceFactory,
 	}
 }

--- a/kaleido/platform/mockserver_test.go
+++ b/kaleido/platform/mockserver_test.go
@@ -46,6 +46,7 @@ type mockPlatform struct {
 	cmsActions      map[string]CMSActionAPIBaseAccessor
 	amsTasks        map[string]*AMSTaskAPIModel
 	amsTaskVersions map[string]map[string]interface{}
+	amsDMUpserts    map[string]map[string]interface{}
 	amsFFListeners  map[string]*AMSFFListenerAPIModel
 	amsDMListeners  map[string]*AMSDMListenerAPIModel
 	groups          map[string]*GroupAPIModel
@@ -67,6 +68,7 @@ func startMockPlatformServer(t *testing.T) *mockPlatform {
 		cmsActions:      make(map[string]CMSActionAPIBaseAccessor),
 		amsTasks:        make(map[string]*AMSTaskAPIModel),
 		amsTaskVersions: make(map[string]map[string]interface{}),
+		amsDMUpserts:    make(map[string]map[string]interface{}),
 		amsFFListeners:  make(map[string]*AMSFFListenerAPIModel),
 		amsDMListeners:  make(map[string]*AMSDMListenerAPIModel),
 		groups:          make(map[string]*GroupAPIModel),
@@ -127,6 +129,9 @@ func startMockPlatformServer(t *testing.T) *mockPlatform {
 	mp.register("/endpoint/{env}/{service}/rest/api/v1/tasks/{task}/versions", http.MethodPost, mp.postAMSTaskVersion)
 	mp.register("/endpoint/{env}/{service}/rest/api/v1/tasks/{task}", http.MethodPatch, mp.patchAMSTask)
 	mp.register("/endpoint/{env}/{service}/rest/api/v1/tasks/{task}", http.MethodDelete, mp.deleteAMSTask)
+
+	// See ams_dmupsert.go
+	mp.register("/endpoint/{env}/{service}/rest/api/v1/bulk/datamodel", http.MethodPut, mp.putAMSDMUpsert)
 
 	// See ams_fflistener.go
 	mp.register("/endpoint/{env}/{service}/rest/api/v1/listeners/firefly/{listener}", http.MethodGet, mp.getAMSFFListener)


### PR DESCRIPTION
This isn't quite like the other resources, as it's an update only (no-op read/delete), but it's useful to be able to use declarative syntax to write information about things like deployed smart contracts