### PR TITLE
[runtime] Support for storageSize, storageType, zone, and subZone

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -14,6 +14,10 @@ jobs:
       - uses: actions/checkout@v4
         with:
           path: 'terraform-provider-kaleido'
+
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_wrapper: false
       
       - name: Set up Go
         uses: actions/setup-go@v5

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -17,6 +17,7 @@ jobs:
 
       - uses: hashicorp/setup-terraform@v3
         with:
+          terraform_version: "1.8.5"
           terraform_wrapper: false
       
       - name: Set up Go

--- a/kaleido/platform/runtime.go
+++ b/kaleido/platform/runtime.go
@@ -38,6 +38,10 @@ type RuntimeResourceModel struct {
 	Size                types.String `tfsdk:"size"`
 	EnvironmentMemberID types.String `tfsdk:"environment_member_id"`
 	Stopped             types.Bool   `tfsdk:"stopped"`
+	Zone                types.String `tfsdk:"zone"`
+	SubZone             types.String `tfsdk:"sub_zone"`
+	StorageSize         types.Int64  `tfsdk:"storage_size"`
+	StorageType         types.String `tfsdk:"storage_type"`
 }
 
 type RuntimeAPIModel struct {
@@ -53,6 +57,10 @@ type RuntimeAPIModel struct {
 	Status              string                 `json:"status,omitempty"`
 	Deleted             bool                   `json:"deleted,omitempty"`
 	Stopped             bool                   `json:"stopped,omitempty"`
+	Zone                string                 `json:"zone,omitempty"`
+	SubZone             string                 `json:"subZone,omitempty"`
+	StorageSize         int64                  `json:"storageSize,omitempty"`
+	StorageType         string                 `json:"storageType,omitempty"`
 }
 
 func RuntimeResourceFactory() resource.Resource {
@@ -103,6 +111,18 @@ func (r *runtimeResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 				Optional: true,
 				Computed: true,
 			},
+			"zone": &schema.StringAttribute{
+				Optional: true,
+			},
+			"sub_zone": &schema.StringAttribute{
+				Optional: true,
+			},
+			"storage_size": &schema.Int64Attribute{
+				Optional: true,
+			},
+			"storage_type": &schema.StringAttribute{
+				Optional: true,
+			},
 		},
 	}
 }
@@ -125,6 +145,18 @@ func (data *RuntimeResourceModel) toAPI(api *RuntimeAPIModel) {
 	if !data.Stopped.IsNull() {
 		api.Stopped = data.Stopped.ValueBool()
 	}
+	if !data.Zone.IsNull() {
+		api.Zone = data.Zone.ValueString()
+	}
+	if !data.SubZone.IsNull() {
+		api.SubZone = data.SubZone.ValueString()
+	}
+	if !data.StorageSize.IsNull() {
+		api.StorageSize = data.StorageSize.ValueInt64()
+	}
+	if !data.StorageType.IsNull() {
+		api.StorageType = data.StorageType.ValueString()
+	}
 }
 
 func (api *RuntimeAPIModel) toData(data *RuntimeResourceModel) {
@@ -133,6 +165,18 @@ func (api *RuntimeAPIModel) toData(data *RuntimeResourceModel) {
 	data.LogLevel = types.StringValue(api.LogLevel)
 	data.Size = types.StringValue(api.Size)
 	data.Stopped = types.BoolValue(api.Stopped)
+	if api.Zone != "" {
+		data.Zone = types.StringValue(api.Zone)
+	}
+	if api.SubZone != "" {
+		data.SubZone = types.StringValue(api.SubZone)
+	}
+	if api.StorageSize != 0 {
+		data.StorageSize = types.Int64Value(api.StorageSize)
+	}
+	if api.StorageType != "" {
+		data.StorageType = types.StringValue(api.StorageType)
+	}
 }
 
 func (r *runtimeResource) apiPath(data *RuntimeResourceModel) string {

--- a/kaleido/platform/runtime.go
+++ b/kaleido/platform/runtime.go
@@ -56,7 +56,7 @@ type RuntimeAPIModel struct {
 	EnvironmentMemberID string                 `json:"environmentMemberId,omitempty"`
 	Status              string                 `json:"status,omitempty"`
 	Deleted             bool                   `json:"deleted,omitempty"`
-	Stopped             bool                   `json:"stopped,omitempty"`
+	Stopped             bool                   `json:"stopped"`
 	Zone                string                 `json:"zone,omitempty"`
 	SubZone             string                 `json:"subZone,omitempty"`
 	StorageSize         int64                  `json:"storageSize,omitempty"`
@@ -120,9 +120,11 @@ func (r *runtimeResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 			},
 			"storage_size": &schema.Int64Attribute{
 				Optional: true,
+				// may be computed for certain storage required runtime types, but we will not track it if the user did not provide it
 			},
 			"storage_type": &schema.StringAttribute{
 				Optional: true,
+				// may be computed for certain runtime types, but we will not track it if the user did not provide it
 			},
 		},
 	}
@@ -166,16 +168,14 @@ func (api *RuntimeAPIModel) toData(data *RuntimeResourceModel) {
 	data.LogLevel = types.StringValue(api.LogLevel)
 	data.Size = types.StringValue(api.Size)
 	data.Stopped = types.BoolValue(api.Stopped)
-	if api.Zone != "" {
-		data.Zone = types.StringValue(api.Zone)
-	}
-	if api.SubZone != "" {
+	data.Zone = types.StringValue(api.Zone)
+	if api.SubZone != "" && !data.SubZone.IsNull() {
 		data.SubZone = types.StringValue(api.SubZone)
 	}
-	if api.StorageSize != 0 {
+	if api.StorageSize > 0 && !data.StorageSize.IsNull() {
 		data.StorageSize = types.Int64Value(api.StorageSize)
 	}
-	if api.StorageType != "" {
+	if api.StorageType != "" && !data.StorageType.IsNull() {
 		data.StorageType = types.StringValue(api.StorageType)
 	}
 }

--- a/kaleido/platform/runtime.go
+++ b/kaleido/platform/runtime.go
@@ -113,6 +113,7 @@ func (r *runtimeResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 			},
 			"zone": &schema.StringAttribute{
 				Optional: true,
+				Computed: true,
 			},
 			"sub_zone": &schema.StringAttribute{
 				Optional: true,

--- a/kaleido/platform/runtime.go
+++ b/kaleido/platform/runtime.go
@@ -169,9 +169,12 @@ func (api *RuntimeAPIModel) toData(data *RuntimeResourceModel) {
 	data.Size = types.StringValue(api.Size)
 	data.Stopped = types.BoolValue(api.Stopped)
 	data.Zone = types.StringValue(api.Zone)
-	if api.SubZone != "" && !data.SubZone.IsNull() {
+	if api.SubZone != "" { // the API should only return a subzone if a subzone was specified
 		data.SubZone = types.StringValue(api.SubZone)
 	}
+	// For storage - it is optional for the user and conditional for the runtime based on its type.
+	// We can't mark it computed as a result, so we only track API storage state if the user provided desired
+	// storage state.
 	if api.StorageSize > 0 && !data.StorageSize.IsNull() {
 		data.StorageSize = types.Int64Value(api.StorageSize)
 	}

--- a/kaleido/platform/runtime_test.go
+++ b/kaleido/platform/runtime_test.go
@@ -36,9 +36,9 @@ resource "kaleido_platform_runtime" "runtime1" {
     config_json = jsonencode({
         "setting1": "value1"
     })
-	zone = "use2"
-	storage_size = 10
-	storage_type = "default"
+    zone = "use2"
+    storage_size = 10
+    storage_type = "default"
 }
 `
 
@@ -54,9 +54,9 @@ resource "kaleido_platform_runtime" "runtime1" {
     log_level = "trace"
     size = "large"
     stopped = false
-	zone = "use2"
-	storage_size = 20
-	storage_type = "default"
+    zone = "use2"
+    storage_size = 20
+    storage_type = "default"
 }
 `
 
@@ -72,9 +72,9 @@ resource "kaleido_platform_runtime" "runtime1" {
     log_level = "trace"
     size = "large"
     stopped = true
-	zone = "use2"
-	storage_size = 20
-	storage_type = "default"
+    zone = "use2"
+    storage_size = 20
+    storage_type = "default"
 }
 `
 
@@ -259,7 +259,6 @@ func (mp *mockPlatform) postRuntime(res http.ResponseWriter, req *http.Request) 
 		rt.StorageSize = 50
 	}
 	rt.Status = "pending"
-	rt.Stopped = false
 	mp.runtimes[mux.Vars(req)["env"]+"/"+rt.ID] = &rt
 	mp.respond(res, &rt, 201)
 }


### PR DESCRIPTION
Allows for leveraging the lower-level features of the platform to customize the scheduling and storage of runtimes, such as Besu and IPFS.