### PR TITLE
[ci] Install terraform for Tests

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -14,7 +14,12 @@ jobs:
       - uses: actions/checkout@v4
         with:
           path: 'terraform-provider-kaleido'
-      
+
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "1.8.5"
+          terraform_wrapper: false
+
       - name: Set up Go
         uses: actions/setup-go@v5
         with:


### PR DESCRIPTION
Running the workflow locally using `act --workflows=./.github/workflows/go.yaml` it failed on my Mac with:
```
| go: downloading github.com/cloudflare/circl v1.3.3
| ?     github.com/kaleido-io/terraform-provider-kaleido        [no test files]
| ?     github.com/kaleido-io/terraform-provider-kaleido/kaleido/kaleidobase    [no test files]
| cannot run Terraform provider tests: failed to find or install Terraform CLI from [0x4000315180 0x40002a2c00]: context deadline exceeded
```

So in relation to #78, wondering if this somehow fixes the v1.1 branch builds before drilling into specific failures there.