### PR TITLE
Fix network types in examples

### DIFF
--- a/examples/platform_stack/main.tf
+++ b/examples/platform_stack/main.tf
@@ -36,7 +36,7 @@ resource "kaleido_platform_stack" "digital_asset_manager_stack" {
 }
 
 resource "kaleido_platform_network" "net_0" {
-  type = "Besu"
+  type = "BesuNetwork"
   name = "evmchain1"
   environment = kaleido_platform_environment.env_0.id
   config_json = jsonencode({

--- a/examples/platform_stack_multiparty_sandbox/main.tf
+++ b/examples/platform_stack_multiparty_sandbox/main.tf
@@ -18,7 +18,7 @@ resource "kaleido_platform_environment" "env_0" {
 }
 
 resource "kaleido_platform_network" "net_0" {
-  type = "Besu"
+  type = "BesuNetwork"
   name = "evmchain1"
   environment = kaleido_platform_environment.env_0.id
   config_json = jsonencode({
@@ -53,7 +53,7 @@ resource "kaleido_platform_service" "bns" {
 }
 
 resource "kaleido_platform_network" "net_ipfs" {
-  type = "IPFS"
+  type = "IPFSNetwork"
   name = "${var.environment_name}_ipfs"
   environment = kaleido_platform_environment.env_0.id
   config_json = jsonencode({})

--- a/examples/platform_stack_two_env_besu_network/main.tf
+++ b/examples/platform_stack_two_env_besu_network/main.tf
@@ -31,7 +31,7 @@ resource "kaleido_platform_environment" "env_og" {
 
 resource "kaleido_platform_network" "net_og" {
   provider = kaleido.originator
-  type = "Besu"
+  type = "BesuNetwork"
   name = var.originator_name
   environment = kaleido_platform_environment.env_og.id
   init_mode = "automated"
@@ -150,7 +150,7 @@ resource "kaleido_platform_environment" "env_sec" {
 
 resource "kaleido_platform_network" "net_sec" {
   provider = kaleido.secondary
-  type = "Besu"
+  type = "BesuNetwork"
   name = var.secondary_name
   environment = kaleido_platform_environment.env_sec.id
   init_mode = "manual"

--- a/kaleido/platform/network_test.go
+++ b/kaleido/platform/network_test.go
@@ -82,7 +82,7 @@ func TestNetwork1(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet(network1Resource, "id"),
 					resource.TestCheckResourceAttr(network1Resource, "name", `network1`),
-					resource.TestCheckResourceAttr(network1Resource, "type", `besu`),
+					resource.TestCheckResourceAttr(network1Resource, "type", `BesuNetwork`),
 					resource.TestCheckResourceAttr(network1Resource, "config_json", `{"setting1":"value1"}`),
 				),
 			},
@@ -91,7 +91,7 @@ func TestNetwork1(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet(network1Resource, "id"),
 					resource.TestCheckResourceAttr(network1Resource, "name", `network1`),
-					resource.TestCheckResourceAttr(network1Resource, "type", `besu`),
+					resource.TestCheckResourceAttr(network1Resource, "type", `BesuNetwork`),
 					resource.TestCheckResourceAttr(network1Resource, "config_json", `{"setting1":"value1","setting2":"value2"}`),
 					resource.TestCheckResourceAttr(network1Resource, "info.setting1", `value1`),
 					resource.TestCheckResourceAttr(network1Resource, "info.setting2", `value2`),
@@ -104,7 +104,7 @@ func TestNetwork1(t *testing.T) {
 							"id": "%[1]s",
 							"created": "%[2]s",
 							"updated": "%[3]s",
-							type = "BesuNetwork"
+							"type": "BesuNetwork",
 							"name": "network1",
 							"config": {
 								"setting1": "value1",

--- a/kaleido/platform/network_test.go
+++ b/kaleido/platform/network_test.go
@@ -31,7 +31,7 @@ import (
 var networkStep1 = `
 resource "kaleido_platform_network" "network1" {
     environment = "env1"
-    type = "besu"
+	type = "BesuNetwork"
     name = "network1"
     config_json = jsonencode({
         "setting1": "value1"
@@ -42,7 +42,7 @@ resource "kaleido_platform_network" "network1" {
 var networkStep2 = `
 resource "kaleido_platform_network" "network1" {
     environment = "env1"
-    type = "besu"
+	type = "BesuNetwork"
     name = "network1"
     config_json = jsonencode({
         "setting1": "value1",
@@ -104,7 +104,7 @@ func TestNetwork1(t *testing.T) {
 							"id": "%[1]s",
 							"created": "%[2]s",
 							"updated": "%[3]s",
-							"type": "besu",
+							type = "BesuNetwork"
 							"name": "network1",
 							"config": {
 								"setting1": "value1",

--- a/kaleido/platform/stacks_test.go
+++ b/kaleido/platform/stacks_test.go
@@ -73,7 +73,7 @@ func TestStacks1(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet(Stack1Resource, "id"),
 					resource.TestCheckResourceAttr(Stack1Resource, "name", `stack1`),
-					resource.TestCheckResourceAttr(Stack1Resource, "network_type", `besu`),
+					resource.TestCheckResourceAttr(Stack1Resource, "network_type", `BesuNetwork`),
 					resource.TestCheckResourceAttr(Stack1Resource, "type", `chain_infrastructure`),
 				),
 			},
@@ -82,7 +82,7 @@ func TestStacks1(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet(Stack1Resource, "id"),
 					resource.TestCheckResourceAttr(Stack1Resource, "name", `stack1_renamed`),
-					resource.TestCheckResourceAttr(Stack1Resource, "network_type", `besu`),
+					resource.TestCheckResourceAttr(Stack1Resource, "network_type", `BesuNetwork`),
 					resource.TestCheckResourceAttr(Stack1Resource, "type", `chain_infrastructure`),
 					func(s *terraform.State) error {
 						// Compare the final result on the mock-server side

--- a/kaleido/platform/stacks_test.go
+++ b/kaleido/platform/stacks_test.go
@@ -33,7 +33,7 @@ resource "kaleido_platform_stack" "stack1" {
 	name = "stack1"
 	type = "chain_infrastructure"
 	environment = "env1"
-	network_type = "besu"
+	network_type = "BesuNetwork"
 }
 `
 
@@ -42,7 +42,7 @@ resource "kaleido_platform_stack" "stack1" {
 	name = "stack1_renamed"
 	type = "chain_infrastructure"
 	environment = "env1"
-	network_type = "besu"
+	network_type = "BesuNetwork"
 }
 `
 
@@ -95,7 +95,7 @@ func TestStacks1(t *testing.T) {
 							"updated": "%[3]s",
 							"type": "chain_infrastructure",
 							"name": "stack1_renamed",
-							"networkType": "besu",
+							"networkType": "BesuNetwork",
 							"environmentMemberId": "%[4]s"
 						}
 						`,
@@ -131,7 +131,7 @@ func (mp *mockPlatform) postStacks(res http.ResponseWriter, req *http.Request) {
 	rt.Updated = &now
 	rt.EnvironmentMemberID = nanoid.New()
 	if rt.NetworkType == "" {
-		rt.NetworkType = "besu"
+		rt.NetworkType = "BesuNetwork"
 	}
 	mp.stacks[mux.Vars(req)["env"]+"/"+rt.ID] = &rt
 	mp.respond(res, &rt, 201)


### PR DESCRIPTION
@chrisbygrave added extra checks today to enforce in service manager adding services of the correct network type within stacks
https://github.com/kaleido-io/firefly-enterprise/pull/3274

Fixing these examples as they will now be caught as errors in dev.

Valid network types can be found here: https://github.com/kaleido-io/firefly-enterprise/blob/main-v3/common/ts-interfaces/src/enums/networks.ts#L1

```
export enum NetworkType {
  BESUNETWORK = 'BesuNetwork',
  IPFSNETWORK = 'IPFSNetwork',
  BITCOINNETWORK = 'BitcoinNetwork',
  ETHEREUMPOSNETWORK = 'EthereumPOSNetwork',
}
```