### PR TITLE
add force delete option for platform services, runtimes, and networks

### DIFF
--- a/kaleido/platform/network.go
+++ b/kaleido/platform/network.go
@@ -44,6 +44,7 @@ type NetworkResourceModel struct {
 	Filesets            types.Map    `tfsdk:"file_sets"`
 	Credsets            types.Map    `tfsdk:"cred_sets"`
 	StatusInitFiles     types.Map    `tfsdk:"status_init_files"`
+	ForceDelete         types.Bool   `tfsdk:"force_delete"`
 }
 
 type NetworkAPIModel struct {
@@ -184,6 +185,9 @@ func (r *networkResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 			"status_init_files": &schema.MapAttribute{
 				Computed:    true,
 				ElementType: types.StringType,
+			},
+			"force_delete": &schema.BoolAttribute{
+				Optional: true,
 			},
 		},
 	}
@@ -338,6 +342,9 @@ func (r *networkResource) apiPath(data *NetworkResourceModel) string {
 	path := fmt.Sprintf("/api/v1/environments/%s/networks", data.Environment.ValueString())
 	if data.ID.ValueString() != "" {
 		path = path + "/" + data.ID.ValueString()
+	}
+	if data.ForceDelete.ValueBool() {
+		path = path + "?force=true"
 	}
 	return path
 }

--- a/kaleido/platform/runtime.go
+++ b/kaleido/platform/runtime.go
@@ -42,6 +42,7 @@ type RuntimeResourceModel struct {
 	SubZone             types.String `tfsdk:"sub_zone"`
 	StorageSize         types.Int64  `tfsdk:"storage_size"`
 	StorageType         types.String `tfsdk:"storage_type"`
+	ForceDelete         types.Bool   `tfsdk:"force_delete"`
 }
 
 type RuntimeAPIModel struct {
@@ -126,6 +127,9 @@ func (r *runtimeResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 				Optional: true,
 				// may be computed for certain runtime types, but we will not track it if the user did not provide it
 			},
+			"force_delete": &schema.BoolAttribute{
+				Optional: true,
+			},
 		},
 	}
 }
@@ -192,6 +196,11 @@ func (r *runtimeResource) apiPath(data *RuntimeResourceModel) string {
 	if data.ID.ValueString() != "" {
 		path = path + "/" + data.ID.ValueString()
 	}
+
+	if data.ForceDelete.ValueBool() {
+		path = path + "?force=true"
+	}
+
 	return path
 }
 

--- a/kaleido/platform/service.go
+++ b/kaleido/platform/service.go
@@ -43,6 +43,7 @@ type ServiceResourceModel struct {
 	Filesets            types.Map    `tfsdk:"file_sets"`
 	Credsets            types.Map    `tfsdk:"cred_sets"`
 	ConnectivityJSON    types.String `tfsdk:"connectivity_json"`
+	ForceDelete         types.Bool   `tfsdk:"force_delete"`
 }
 
 type ServiceAPIModel struct {
@@ -215,6 +216,9 @@ func (r *serviceResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 			"connectivity_json": &schema.StringAttribute{
 				Computed: true,
 			},
+			"force_delete": &schema.BoolAttribute{
+				Optional: true,
+			},
 		},
 	}
 }
@@ -381,6 +385,11 @@ func (r *serviceResource) apiPath(data *ServiceResourceModel) string {
 	if data.ID.ValueString() != "" {
 		path = path + "/" + data.ID.ValueString()
 	}
+
+	if data.ForceDelete.ValueBool() {
+		path = path + "?force=true"
+	}
+
 	return path
 }
 


### PR DESCRIPTION
Exposing the `force` parameter for deleting Kaleido platform services. 