### PR TITLE
[util] Set User-Agent Header for Diagnostics

### DIFF
--- a/kaleido/kaleidobase/providerdata.go
+++ b/kaleido/kaleidobase/providerdata.go
@@ -26,7 +26,7 @@ import (
 	kaleido "github.com/kaleido-io/kaleido-sdk-go/kaleido"
 )
 
-const version = "v1.2.0"
+const version = "v1.1.0"
 
 type ProviderData struct {
 	BaaS     *kaleido.KaleidoClient

--- a/kaleido/kaleidobase/providerdata.go
+++ b/kaleido/kaleidobase/providerdata.go
@@ -73,7 +73,8 @@ func NewProviderData(logCtx context.Context, conf *ProviderModel) *ProviderData 
 	r := resty.New().
 		SetTransport(http.DefaultTransport).
 		SetBaseURL(baasAPI).
-		SetAuthToken(baasAPIKey)
+		SetAuthToken(baasAPIKey).
+                SetHeader("User-Agent", fmt.Sprintf("Terraform / %s (BaaS)", version))
 	AddRestyLogging(logCtx, r)
 	baas := &kaleido.KaleidoClient{Client: r}
 
@@ -91,7 +92,7 @@ func NewProviderData(logCtx context.Context, conf *ProviderModel) *ProviderData 
 	}
 	platform := resty.New().
 		SetTransport(http.DefaultTransport).
-		SetHeader("User-Agent", fmt.Sprintf("Terraform / %s", version)).
+		SetHeader("User-Agent", fmt.Sprintf("Terraform / %s (Platform)", version)).
 		SetBaseURL(platformAPI)
 	if platformUsername != "" && platformPassword != "" {
 		platform = platform.SetBasicAuth(platformUsername, platformPassword)

--- a/kaleido/kaleidobase/providerdata.go
+++ b/kaleido/kaleidobase/providerdata.go
@@ -26,6 +26,8 @@ import (
 	kaleido "github.com/kaleido-io/kaleido-sdk-go/kaleido"
 )
 
+const version = "v1.2.0"
+
 type ProviderData struct {
 	BaaS     *kaleido.KaleidoClient
 	Platform *resty.Client
@@ -89,6 +91,7 @@ func NewProviderData(logCtx context.Context, conf *ProviderModel) *ProviderData 
 	}
 	platform := resty.New().
 		SetTransport(http.DefaultTransport).
+		SetHeader("User-Agent", fmt.Sprintf("Terraform / %s", version)).
 		SetBaseURL(platformAPI)
 	if platformUsername != "" && platformPassword != "" {
 		platform = platform.SetBasicAuth(platformUsername, platformPassword)


### PR DESCRIPTION
There's ways to eventually set this `Version` via build args so that other info like commit hash, etc. could be included. But this alone will help us to distinguish traffic from our UI vs. Terraform users more easily, and see what versions people are on going forward.