### PR TITLE
Rename authenticators to connectors

### DIFF
--- a/examples/platform_stack_two_env_besu_network/main.tf
+++ b/examples/platform_stack_two_env_besu_network/main.tf
@@ -213,11 +213,11 @@ resource "kaleido_platform_service" "gws_net_sec" {
 }
 
 
-// Authenticators
-resource "kaleido_platform_authenticator" "net_sec_authenticator" {
+// Network Connectors
+resource "kaleido_network_connector" "net_sec_connector" {
   provider = kaleido.secondary
   type = "Permitted"
-  name = "${var.secondary_name}_auth"
+  name = "${var.secondary_name}_conn"
   environment = kaleido_platform_environment.env_sec.id
   network = kaleido_platform_network.net_sec.id
   zone = var.secondary_peer_network_dz
@@ -227,10 +227,10 @@ resource "kaleido_platform_authenticator" "net_sec_authenticator" {
 }
 
 
-resource "kaleido_platform_authenticator" "net_og_authenticator" {
+resource "kaleido_network_connector" "net_og_connector" {
   provider = kaleido.originator
   type = "Permitted"
-  name = "${var.originator_name}_auth"
+  name = "${var.originator_name}_"
   environment = kaleido_platform_environment.env_og.id
   network = kaleido_platform_network.net_og.id
   zone = var.originator_peer_network_dz

--- a/kaleido/platform/common.go
+++ b/kaleido/platform/common.go
@@ -361,7 +361,7 @@ func Resources() []func() resource.Resource {
 		AMSDMUpsertResourceFactory,
 		AMSVariableSetResourceFactory,
 		FireFlyRegistrationResourceFactory,
-		AuthenticatorResourceFactory,
+		ConnectorResourceFactory,
 		ApplicationResourceFactory,
 		APIKeyResourceFactory,
 	}

--- a/kaleido/platform/mockserver_test.go
+++ b/kaleido/platform/mockserver_test.go
@@ -40,7 +40,7 @@ type mockPlatform struct {
 	runtimes          map[string]*RuntimeAPIModel
 	services          map[string]*ServiceAPIModel
 	networks          map[string]*NetworkAPIModel
-	authenticators    map[string]*AuthenticatorAPIModel
+	connectors        map[string]*ConnectorAPIModel
 	networkinitdatas  map[string]*NetworkInitData
 	kmsWallets        map[string]*KMSWalletAPIModel
 	kmsKeys           map[string]*KMSKeyAPIModel
@@ -70,7 +70,7 @@ func startMockPlatformServer(t *testing.T) *mockPlatform {
 		runtimes:          make(map[string]*RuntimeAPIModel),
 		services:          make(map[string]*ServiceAPIModel),
 		networks:          make(map[string]*NetworkAPIModel),
-		authenticators:    make(map[string]*AuthenticatorAPIModel),
+		connectors:        make(map[string]*ConnectorAPIModel),
 		networkinitdatas:  make(map[string]*NetworkInitData),
 		kmsWallets:        make(map[string]*KMSWalletAPIModel),
 		kmsKeys:           make(map[string]*KMSKeyAPIModel),
@@ -115,11 +115,11 @@ func startMockPlatformServer(t *testing.T) *mockPlatform {
 	mp.register("/api/v1/environments/{env}/networks/{network}", http.MethodPut, mp.putNetwork)
 	mp.register("/api/v1/environments/{env}/networks/{network}", http.MethodDelete, mp.deleteNetwork)
 
-	// See authenticator_test.go
-	mp.register("/api/v1/environments/{env}/networks/{net}/authenticators", http.MethodPost, mp.postAuthenticator)
-	mp.register("/api/v1/environments/{env}/networks/{net}/authenticators/{authenticator}", http.MethodGet, mp.getAuthenticator)
-	mp.register("/api/v1/environments/{env}/networks/{net}/authenticators/{authenticator}", http.MethodPut, mp.putAuthenticator)
-	mp.register("/api/v1/environments/{env}/networks/{net}/authenticators/{authenticator}", http.MethodDelete, mp.deleteAuthenticator)
+	// See connector_test.go
+	mp.register("/api/v1/environments/{env}/networks/{net}/connectors", http.MethodPost, mp.postConnector)
+	mp.register("/api/v1/environments/{env}/networks/{net}/connectors/{connector}", http.MethodGet, mp.getConnector)
+	mp.register("/api/v1/environments/{env}/networks/{net}/connectors/{connector}", http.MethodPut, mp.putConnector)
+	mp.register("/api/v1/environments/{env}/networks/{net}/connectors/{connector}", http.MethodDelete, mp.deleteConnector)
 
 	// See network_bootstrap_test.go
 	mp.register("/api/v1/environments/{env}/networks/{network}/initdata", http.MethodGet, mp.getNetworkInitData)


### PR DESCRIPTION
The authenticators resource has been changed to connectors, updating the terraform to reflect that.

The `connection` attribute has also been removed in this change.