### PR TITLE
Add requireReplace to the stack id attribute for services and runtimes

### DIFF
--- a/kaleido/platform/runtime.go
+++ b/kaleido/platform/runtime.go
@@ -93,7 +93,8 @@ func (r *runtimeResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 				Required: true,
 			},
 			"stack_id": &schema.StringAttribute{
-				Optional: true,
+				Optional:      true,
+				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"environment": &schema.StringAttribute{
 				Required:      true,

--- a/kaleido/platform/service.go
+++ b/kaleido/platform/service.go
@@ -127,7 +127,8 @@ func (r *serviceResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 				Required: true,
 			},
 			"stack_id": &schema.StringAttribute{
-				Optional: true,
+				Optional:      true,
+				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"environment_member_id": &schema.StringAttribute{
 				Computed: true,

--- a/kaleido/platform/stacks.go
+++ b/kaleido/platform/stacks.go
@@ -81,7 +81,8 @@ func (r *stacksResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 				Computed: true,
 			},
 			"network_id": &schema.StringAttribute{
-				Optional: true,
+				Optional:      true,
+				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 		},
 	}


### PR DESCRIPTION
Moving Runtimes/ Services between stacks is supported in the Kaleido Platform console 