### PR TITLE
[connectors] [accounts] Data Source for Account ID Info and Platform Connector Support

### DIFF
--- a/examples/platform_multiaccountenv_testnets/.gitignore
+++ b/examples/platform_multiaccountenv_testnets/.gitignore
@@ -1,0 +1,4 @@
+.terraform*
+terraform.d
+terraform.tfstate*
+input.tfvars

--- a/examples/platform_multiaccountenv_testnets/README.md
+++ b/examples/platform_multiaccountenv_testnets/README.md
@@ -1,0 +1,14 @@
+## platform_multiaccountenv_testnets
+
+This module creates a shared Besu QBFT and IPFS testnet across three different accounts and environments w/in a Kaleido
+platform instance.
+
+The originator account creates the testnets and the joiner accounts join the testnets via
+`Platform` network connectors. Joiner one requests to connect with the originator. The originator accepts the joiner
+one request, and requests joiner two to connect. Joiner two accepts the request.
+
+This represents how to create a shared network across multiple accounts and environments in a Kaleido platform instance
+for software or consortium use cases.
+
+**NOTE**: network connectors are experimental and must be enabled on your Kaleido platform instance. Please contact
+support if you would like to use this feature.

--- a/examples/platform_multiaccountenv_testnets/input.tfvars.example
+++ b/examples/platform_multiaccountenv_testnets/input.tfvars.example
@@ -1,0 +1,27 @@
+originator_api_url = "https://nodes.kaleido.dev"
+originator_api_key_name = "nodes"
+originator_api_key_value = "***"
+
+joiner_one_api_url = "https://nodes1.kaleido.dev"
+joiner_one_api_key_name = "nodes1"
+joiner_one_api_key_value = "***"
+
+joiner_two_api_url = "https://nodes2.kaleido.dev"
+joiner_two_api_key_name = "nodes2"
+joiner_two_api_key_value = "***"
+
+originator_name = "originator"
+originator_signer_count = 1
+originator_peer_count = 1
+originator_peer_network_dz = "platform-conn"
+originator_peer_network_connection = "platform"
+
+joiner_one_name = "joiner_one"
+joiner_one_peer_count = 1
+joiner_one_peer_network_dz = "platform-conn"
+joiner_one_peer_network_connection = "platform"
+
+joiner_two_name = "joiner_two"
+joiner_two_peer_count = 1
+joiner_two_peer_network_dz = "platform-conn"
+joiner_two_peer_network_connection = "platform"

--- a/examples/platform_multiaccountenv_testnets/main.tf
+++ b/examples/platform_multiaccountenv_testnets/main.tf
@@ -232,16 +232,16 @@ resource "kaleido_platform_service" "ins_net_og" {
 
 // Environment 2 - another member of the testnets joining
 resource "kaleido_platform_stack" "chain_infra_besu_stack_j1" {
-  provider = kaleido.originator
-  environment = kaleido_platform_environment.env_og.id
+  provider = kaleido.joiner_one
+  environment = kaleido_platform_environment.env_j1.id
   name = "chain_infra_besu_stack"
   type = "chain_infrastructure"
   network_id = kaleido_platform_network.besunet_j1.id
 }
 
 resource "kaleido_platform_stack" "chain_infra_ipfs_stack_j1" {
-  provider = kaleido.originator
-  environment = kaleido_platform_environment.env_og.id
+  provider = kaleido.joiner_one
+  environment = kaleido_platform_environment.env_j1.id
   name = "chain_infra_ipfs_stack"
   type = "chain_infrastructure"
   network_id = kaleido_platform_network.ipfsnet_j1.id
@@ -358,19 +358,19 @@ resource "kaleido_platform_service" "ins_net_j1" {
 
 // Environment 3 - another member of the testnets joining
 resource "kaleido_platform_stack" "chain_infra_besu_stack_j2" {
-  provider = kaleido.originator
-  environment = kaleido_platform_environment.env_og.id
+  provider = kaleido.joiner_two
+  environment = kaleido_platform_environment.env_j2.id
   name = "chain_infra_besu_stack"
   type = "chain_infrastructure"
-  network_id = kaleido_platform_network.besunet_j1.id
+  network_id = kaleido_platform_network.besunet_j2.id
 }
 
 resource "kaleido_platform_stack" "chain_infra_ipfs_stack_j2" {
-  provider = kaleido.originator
-  environment = kaleido_platform_environment.env_og.id
+  provider = kaleido.joiner_two
+  environment = kaleido_platform_environment.env_j2.id
   name = "chain_infra_ipfs_stack"
   type = "chain_infrastructure"
-  network_id = kaleido_platform_network.ipfsnet_j1.id
+  network_id = kaleido_platform_network.ipfsnet_j2.id
 }
 
 

--- a/examples/platform_multiaccountenv_testnets/main.tf
+++ b/examples/platform_multiaccountenv_testnets/main.tf
@@ -1,10 +1,4 @@
-// This module creates a shared Besu QBFT and IPFS testnet across three different accounts and environments w/in a Kaleido
-// platform instance. The originator account creates the testnets and the joiner accounts join the testnets via
-// "platform" network connectors. Joiner one requests to connect with the originator. The originator accepts the joiner
-// one request, and requests joiner two to connect. Joiner two accepts the request.
-//
-// This represent how to create a shared network across multiple accounts and environments in a Kaleido platform instance
-// for software or consortium use cases.
+
 
 terraform {
   required_providers {

--- a/examples/platform_multiaccountenv_testnets/main.tf
+++ b/examples/platform_multiaccountenv_testnets/main.tf
@@ -1,0 +1,546 @@
+// This module creates a shared Besu QBFT and IPFS testnet across three different accounts and environments w/in a Kaleido
+// platform instance. The originator account creates the testnets and the joiner accounts join the testnets via
+// "platform" network connectors. Joiner one requests to connect with the originator. The originator accepts the joiner
+// one request, and requests joiner two to connect. Joiner two accepts the request.
+//
+// This represent how to create a shared network across multiple accounts and environments in a Kaleido platform instance
+// for software or consortium use cases.
+
+terraform {
+  required_providers {
+    kaleido = {
+      source = "kaleido-io/kaleido"
+      configuration_aliases = [kaleido.originator, kaleido.joiner_one, kaleido.joiner_two]
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "3.6.3"
+    }
+  }
+}
+
+provider "kaleido" {
+  alias = "originator"
+  platform_api = var.originator_api_url
+  platform_username = var.originator_api_key_name
+  platform_password = var.originator_api_key_value
+}
+
+data "kaleido_platform_account" "acct_og" {
+    provider = kaleido.originator
+}
+
+provider "kaleido" {
+  alias = "joiner_one"
+  platform_api = var.joiner_one_api_url
+  platform_username = var.joiner_one_api_key_name
+  platform_password = var.joiner_one_api_key_value
+}
+
+data "kaleido_platform_account" "acct_j1" {
+  provider = kaleido.joiner_one
+}
+
+provider "kaleido" {
+  alias = "joiner_two"
+  platform_api = var.joiner_two_api_url
+  platform_username = var.joiner_two_api_key_name
+  platform_password = var.joiner_two_api_key_value
+}
+
+data "kaleido_platform_account" "acct_j2" {
+  provider = kaleido.joiner_two
+}
+
+provider "random" {}
+
+// Environment 1 - the originator of the testnets
+
+resource "kaleido_platform_environment" "env_og" {
+  provider = kaleido.originator
+  name = var.originator_name
+}
+
+resource "kaleido_platform_network" "besunet_og" {
+  provider = kaleido.originator
+  type = "BesuNetwork"
+  name = var.besu_testnet_name
+  environment = kaleido_platform_environment.env_og.id
+  init_mode = "automated"
+
+  config_json = jsonencode({
+    chainID = 12345
+    bootstrapOptions = {
+      qbft = {
+        blockperiodseconds = 5
+      }
+      eipBlockConfig = {
+        shanghaiTime = 0
+      }
+      initialBalances = {
+        "0x12F62772C4652280d06E64CfBC9033d409559aD4" = "0x111111111111",
+      }
+      blockConfigFlags = {
+        zeroBaseFee = true
+      }
+    }
+  })
+}
+
+resource "random_id" "swarm_key_og" {
+  byte_length = 32
+}
+
+resource "kaleido_platform_network" "ipfsnet_og" {
+  provider = kaleido.originator
+  type = "IPFSNetwork"
+  name = var.ipfs_testnet_name
+  environment = kaleido_platform_environment.env_og.id
+  config_json = jsonencode({
+    swarmKey = random_id.swarm_key_og.hex
+  })
+}
+
+resource "kaleido_platform_runtime" "bnr_signer_net_og" {
+  provider = kaleido.originator
+  type = "BesuNode"
+  name = "${var.originator_name}_signer${count.index+1}"
+  environment = kaleido_platform_environment.env_og.id
+  config_json = jsonencode({})
+  count = var.originator_signer_count
+}
+
+resource "kaleido_platform_service" "bns_signer_net_og" {
+  provider = kaleido.originator
+  type = "BesuNode"
+  name = "${var.originator_name}_signer${count.index+1}"
+  environment = kaleido_platform_environment.env_og.id
+  runtime = kaleido_platform_runtime.bnr_signer_net_og[count.index].id
+  config_json = jsonencode({
+    network = {
+      id = kaleido_platform_network.besunet_og.id
+    }
+    signer = true
+  })
+  count = var.originator_signer_count
+}
+
+resource "kaleido_platform_runtime" "bnr_peer_net_og" {
+  provider = kaleido.originator
+  type = "BesuNode"
+  name = "${var.originator_name}_peer${count.index+1}"
+  environment = kaleido_platform_environment.env_og.id
+  zone = var.originator_peer_network_dz
+  config_json = jsonencode({})
+  count = var.originator_peer_count
+}
+
+resource "kaleido_platform_service" "bns_peer_net_og" {
+  provider = kaleido.originator
+  type = "BesuNode"
+  name = "${var.originator_name}_peer${count.index+1}"
+  environment = kaleido_platform_environment.env_og.id
+  runtime = kaleido_platform_runtime.bnr_peer_net_og[count.index].id
+  config_json = jsonencode({
+    network = {
+      id = kaleido_platform_network.besunet_og.id
+    }
+    signer = false
+  })
+  count = var.originator_peer_count
+}
+
+resource "kaleido_platform_runtime" "gwr_net_og" {
+  provider = kaleido.originator
+  type = "EVMGateway"
+  name = "${var.originator_name}_gateway"
+  environment = kaleido_platform_environment.env_og.id
+  config_json = jsonencode({})
+  count = var.originator_gateway_count
+}
+
+
+resource "kaleido_platform_service" "gws_net_og" {
+  provider = kaleido.originator
+  type = "EVMGateway"
+  name = "${var.originator_name}_gateway"
+  environment = kaleido_platform_environment.env_og.id
+  runtime = kaleido_platform_runtime.gwr_net_og[count.index].id
+  config_json = jsonencode({
+    network = {
+      id =  kaleido_platform_network.besunet_og.id
+    }
+  })
+  count = var.originator_gateway_count
+}
+
+data "kaleido_platform_network_bootstrap_data" "net_og_bootstrap" {
+  provider = kaleido.originator
+  environment = kaleido_platform_environment.env_og.id
+  network = kaleido_platform_network.besunet_og.id
+  depends_on = [
+    kaleido_platform_service.bns_signer_net_og,
+    kaleido_platform_network.besunet_og
+  ]
+}
+
+
+resource "kaleido_platform_runtime" "inr_net_og" {
+  provider = kaleido.originator
+
+  type = "IPFSNode"
+  name = var.originator_name
+  environment = kaleido_platform_environment.env_og.id
+  config_json = jsonencode({ })
+}
+
+resource "kaleido_platform_service" "ins_net_og" {
+  provider = kaleido.originator
+
+  type = "IPFSNode"
+  name = var.originator_name
+  environment = kaleido_platform_environment.env_og.id
+  runtime = kaleido_platform_runtime.inr_net_og.id
+  config_json = jsonencode({
+    network = {
+      id = kaleido_platform_network.ipfsnet_og.id
+    }
+  })
+}
+
+
+// Environment 2 - another member of the testnets joining
+
+resource "kaleido_platform_environment" "env_j1" {
+  provider = kaleido.joiner_one
+  name = var.joiner_one_name
+}
+
+resource "kaleido_platform_network" "besunet_j1" {
+  provider = kaleido.joiner_one
+  type = "BesuNetwork"
+  name = var.joiner_one_name
+  environment = kaleido_platform_environment.env_j1.id
+  init_mode = "manual"
+  file_sets = data.kaleido_platform_network_bootstrap_data.net_og_bootstrap.bootstrap_files != null ? {
+    init = data.kaleido_platform_network_bootstrap_data.net_og_bootstrap.bootstrap_files
+  } : {}
+  init_files = data.kaleido_platform_network_bootstrap_data.net_og_bootstrap.bootstrap_files != null ? "init" : null
+  config_json = jsonencode({})
+  depends_on = [kaleido_platform_network.besunet_og, kaleido_platform_service.bns_signer_net_og, data.kaleido_platform_network_bootstrap_data.net_og_bootstrap]
+}
+
+resource "kaleido_platform_network" "ipfsnet_j1" {
+  provider = kaleido.joiner_one
+  type = "IPFSNetwork"
+  name = var.ipfs_testnet_name
+  environment = kaleido_platform_environment.env_j1.id
+  config_json = jsonencode({
+    swarmKey = random_id.swarm_key_og.hex
+  })
+}
+
+resource "kaleido_platform_runtime" "bnr_peer_net_j1" {
+  provider = kaleido.joiner_one
+  type = "BesuNode"
+  name = "${var.joiner_one_name}_peer${count.index+1}"
+  environment = kaleido_platform_environment.env_j1.id
+  zone = var.joiner_one_peer_network_dz
+  config_json = jsonencode({})
+  count = var.joiner_one_peer_count
+  depends_on = [kaleido_platform_network.besunet_j1]
+}
+
+resource "kaleido_platform_service" "bns_peer_net_j1" {
+  provider = kaleido.joiner_one
+  type = "BesuNode"
+  name = "${var.joiner_one_name}_peer${count.index+1}"
+  environment = kaleido_platform_environment.env_j1.id
+  runtime = kaleido_platform_runtime.bnr_peer_net_j1[count.index].id
+  config_json = jsonencode({
+    network = {
+      id = kaleido_platform_network.besunet_j1.id
+    }
+    signer = false
+  })
+  count = var.joiner_one_peer_count
+}
+
+resource "kaleido_platform_runtime" "gwr_net_j1" {
+  provider = kaleido.joiner_one
+  type = "EVMGateway"
+  name = "${var.originator_name}_gateway"
+  environment = kaleido_platform_environment.env_j1.id
+  config_json = jsonencode({})
+  depends_on = [kaleido_platform_network.besunet_j1]
+  count = var.joiner_one_gateway_count
+}
+
+resource "kaleido_platform_service" "gws_net_j1" {
+  provider = kaleido.joiner_one
+  type = "EVMGateway"
+  name = "${var.originator_name}_gateway"
+  environment = kaleido_platform_environment.env_j1.id
+  runtime = kaleido_platform_runtime.gwr_net_j1[count.index].id
+  config_json = jsonencode({
+    network = {
+      id =  kaleido_platform_network.besunet_j1.id
+    }
+  })
+  count = var.joiner_one_gateway_count
+}
+
+resource "kaleido_platform_runtime" "inr_net_j1" {
+  provider = kaleido.joiner_one
+
+  type = "IPFSNode"
+  name = var.joiner_one_name
+  environment = kaleido_platform_environment.env_j1.id
+  config_json = jsonencode({ })
+}
+
+resource "kaleido_platform_service" "ins_net_j1" {
+  provider = kaleido.joiner_one
+
+  type = "IPFSNode"
+  name = var.joiner_one_name
+  environment = kaleido_platform_environment.env_j1.id
+  runtime = kaleido_platform_runtime.inr_net_j1.id
+  config_json = jsonencode({
+    network = {
+      id = kaleido_platform_network.ipfsnet_j1.id
+    }
+  })
+}
+
+// Environment 3 - another member of the testnets joining
+
+resource "kaleido_platform_environment" "env_j2" {
+  provider = kaleido.joiner_two
+  name = var.joiner_two_name
+}
+
+resource "kaleido_platform_network" "besunet_j2" {
+  provider = kaleido.joiner_two
+  type = "BesuNetwork"
+  name = var.joiner_two_name
+  environment = kaleido_platform_environment.env_j2.id
+  init_mode = "manual"
+  file_sets = data.kaleido_platform_network_bootstrap_data.net_og_bootstrap.bootstrap_files != null ? {
+    init = data.kaleido_platform_network_bootstrap_data.net_og_bootstrap.bootstrap_files
+  } : {}
+  init_files = data.kaleido_platform_network_bootstrap_data.net_og_bootstrap.bootstrap_files != null ? "init" : null
+  config_json = jsonencode({})
+  depends_on = [kaleido_platform_network.besunet_og, kaleido_platform_service.bns_signer_net_og, data.kaleido_platform_network_bootstrap_data.net_og_bootstrap]
+}
+
+resource "kaleido_platform_network" "ipfsnet_j2" {
+  provider = kaleido.joiner_two
+  type = "IPFSNetwork"
+  name = var.ipfs_testnet_name
+  environment = kaleido_platform_environment.env_j2.id
+  config_json = jsonencode({
+    swarmKey = random_id.swarm_key_og.hex
+  })
+}
+
+resource "kaleido_platform_runtime" "bnr_peer_net_j2" {
+  provider = kaleido.joiner_two
+  type = "BesuNode"
+  name = "${var.joiner_two_name}_peer${count.index+1}"
+  environment = kaleido_platform_environment.env_j2.id
+  zone = var.joiner_two_peer_network_dz
+  config_json = jsonencode({})
+  count = var.joiner_two_peer_count
+  depends_on = [kaleido_platform_network.besunet_j2]
+}
+
+resource "kaleido_platform_service" "bns_peer_net_j2" {
+  provider = kaleido.joiner_two
+  type = "BesuNode"
+  name = "${var.joiner_two_name}_peer${count.index+1}"
+  environment = kaleido_platform_environment.env_j2.id
+  runtime = kaleido_platform_runtime.bnr_peer_net_j2[count.index].id
+  config_json = jsonencode({
+    network = {
+      id = kaleido_platform_network.besunet_j2.id
+    }
+    signer = false
+  })
+  count = var.joiner_two_peer_count
+}
+
+resource "kaleido_platform_runtime" "gwr_net_j2" {
+  provider = kaleido.joiner_two
+  type = "EVMGateway"
+  name = "${var.originator_name}_gateway"
+  environment = kaleido_platform_environment.env_j2.id
+  config_json = jsonencode({})
+  depends_on = [kaleido_platform_network.besunet_j2]
+  count = var.joiner_two_gateway_count
+}
+
+resource "kaleido_platform_service" "gws_net_j2" {
+  provider = kaleido.joiner_two
+  type = "EVMGateway"
+  name = "${var.originator_name}_gateway"
+  environment = kaleido_platform_environment.env_j2.id
+  runtime = kaleido_platform_runtime.gwr_net_j2[count.index].id
+  config_json = jsonencode({
+    network = {
+      id =  kaleido_platform_network.besunet_j2.id
+    }
+  })
+  count = var.joiner_two_gateway_count
+}
+
+resource "kaleido_platform_runtime" "inr_net_j2" {
+  provider = kaleido.joiner_two
+
+  type = "IPFSNode"
+  name = var.joiner_two_name
+  environment = kaleido_platform_environment.env_j2.id
+  config_json = jsonencode({ })
+}
+
+resource "kaleido_platform_service" "ins_net_j2" {
+  provider = kaleido.joiner_two
+
+  type = "IPFSNode"
+  name = var.joiner_two_name
+  environment = kaleido_platform_environment.env_j2.id
+  runtime = kaleido_platform_runtime.inr_net_j2.id
+  config_json = jsonencode({
+    network = {
+      id = kaleido_platform_network.ipfsnet_j2.id
+    }
+  })
+}
+
+// Besu Network Connectors
+resource "kaleido_network_connector" "besunet_j1_connector_og" {
+  provider = kaleido.joiner_one
+  type = "Platform"
+  name = "${var.joiner_one_name}_conn_${var.originator_name}"
+  environment = kaleido_platform_environment.env_j1.id
+  network = kaleido_platform_network.besunet_j1.id
+  zone = var.joiner_one_peer_network_dz
+
+  platform_requestor = {
+    target_account_id = data.kaleido_platform_account.acct_og.account_id
+    target_environment_id = kaleido_platform_environment.env_og.id
+    target_network_id = kaleido_platform_network.besunet_og.id
+  }
+}
+
+
+resource "kaleido_network_connector" "besunet_og_connector_j1" {
+  provider = kaleido.originator
+  type = "Platform"
+  name = "${var.originator_name}_conn_${var.joiner_one_name}"
+  environment = kaleido_platform_environment.env_og.id
+  network = kaleido_platform_network.besunet_og.id
+  zone = var.originator_peer_network_dz
+
+  platform_acceptor = {
+    target_account_id = data.kaleido_platform_account.acct_j1.account_id
+    target_environment_id = kaleido_platform_environment.env_j1.id
+    target_network_id = kaleido_platform_network.besunet_j1.id
+    target_connector_id = kaleido_network_connector.besunet_j1_connector_og.id
+  }
+}
+
+resource "kaleido_network_connector" "besunet_og_connector_j2" {
+  provider = kaleido.originator
+  type = "Platform"
+  name = "${var.originator_name}_conn_${var.joiner_two_name}"
+  environment = kaleido_platform_environment.env_og.id
+  network = kaleido_platform_network.besunet_og.id
+  zone = var.originator_peer_network_dz
+
+  platform_requestor = {
+    target_account_id = data.kaleido_platform_account.acct_j2.account_id
+    target_environment_id = kaleido_platform_environment.env_j2.id
+    target_network_id = kaleido_platform_network.besunet_j2.id
+  }
+}
+
+resource "kaleido_network_connector" "besunet_j2_connector_og" {
+  provider = kaleido.originator
+  type = "Platform"
+  name = "${var.joiner_two_name}_conn_${var.originator_name}"
+  environment = kaleido_platform_environment.env_j2.id
+  network = kaleido_platform_network.besunet_j2.id
+  zone = var.joiner_two_peer_network_dz
+
+  platform_acceptor = {
+    target_account_id = data.kaleido_platform_account.acct_og.account_id
+    target_environment_id = kaleido_platform_environment.env_og.id
+    target_network_id = kaleido_platform_network.besunet_og.id
+    target_connector_id = kaleido_network_connector.besunet_og_connector_j2.id
+  }
+}
+
+// IPFS Network Connectors
+resource "kaleido_network_connector" "ipfsnet_j1_connector_og" {
+  provider = kaleido.joiner_one
+  type = "Platform"
+  name = "${var.joiner_one_name}_conn_${var.originator_name}"
+  environment = kaleido_platform_environment.env_j1.id
+  network = kaleido_platform_network.ipfsnet_j1.id
+  zone = var.joiner_one_peer_network_dz
+
+  platform_requestor = {
+    target_account_id = data.kaleido_platform_account.acct_og.account_id
+    target_environment_id = kaleido_platform_environment.env_og.id
+    target_network_id = kaleido_platform_network.ipfsnet_og.id
+  }
+}
+
+
+resource "kaleido_network_connector" "ipfsnet_og_connector_j1" {
+  provider = kaleido.originator
+  type = "Platform"
+  name = "${var.originator_name}_conn_${var.joiner_one_name}"
+  environment = kaleido_platform_environment.env_og.id
+  network = kaleido_platform_network.ipfsnet_og.id
+  zone = var.originator_peer_network_dz
+
+  platform_acceptor = {
+    target_account_id = data.kaleido_platform_account.acct_j1.account_id
+    target_environment_id = kaleido_platform_environment.env_j1.id
+    target_network_id = kaleido_platform_network.ipfsnet_j1.id
+    target_connector_id = kaleido_network_connector.ipfsnet_j1_connector_og.id
+  }
+}
+
+resource "kaleido_network_connector" "ipfsnet_og_connector_j2" {
+  provider = kaleido.originator
+  type = "Platform"
+  name = "${var.originator_name}_conn_${var.joiner_two_name}"
+  environment = kaleido_platform_environment.env_og.id
+  network = kaleido_platform_network.ipfsnet_og.id
+  zone = var.originator_peer_network_dz
+
+  platform_requestor = {
+    target_account_id = data.kaleido_platform_account.acct_j2.account_id
+    target_environment_id = kaleido_platform_environment.env_j2.id
+    target_network_id = kaleido_platform_network.ipfsnet_j2.id
+  }
+}
+
+resource "kaleido_network_connector" "ipfsnet_j2_connector_og" {
+  provider = kaleido.joiner_two
+  type = "Platform"
+  name = "${var.joiner_two_name}_conn_${var.originator_name}"
+  environment = kaleido_platform_environment.env_j2.id
+  network = kaleido_platform_network.ipfsnet_j2.id
+  zone = var.joiner_two_peer_network_dz
+
+  platform_acceptor = {
+    target_account_id = data.kaleido_platform_account.acct_og.account_id
+    target_environment_id = kaleido_platform_environment.env_og.id
+    target_network_id = kaleido_platform_network.ipfsnet_og.id
+    target_connector_id = kaleido_network_connector.ipfsnet_og_connector_j2.id
+  }
+}

--- a/examples/platform_multiaccountenv_testnets/main.tf
+++ b/examples/platform_multiaccountenv_testnets/main.tf
@@ -123,6 +123,7 @@ resource "kaleido_platform_service" "bns_signer_net_og" {
     signer = true
   })
   count = var.originator_signer_count
+  force_delete = true
 }
 
 resource "kaleido_platform_runtime" "bnr_peer_net_og" {

--- a/examples/platform_multiaccountenv_testnets/main.tf
+++ b/examples/platform_multiaccountenv_testnets/main.tf
@@ -55,6 +55,23 @@ resource "kaleido_platform_environment" "env_og" {
   name = var.originator_name
 }
 
+
+resource "kaleido_platform_stack" "chain_infra_besu_stack_og" {
+  provider = kaleido.originator
+  environment = kaleido_platform_environment.env_og.id
+  name = "chain_infra_besu_stack"
+  type = "chain_infrastructure"
+  network_id = kaleido_platform_network.besunet_og.id
+}
+
+resource "kaleido_platform_stack" "chain_infra_ipfs_stack_og" {
+  provider = kaleido.originator
+  environment = kaleido_platform_environment.env_og.id
+  name = "chain_infra_ipfs_stack"
+  type = "chain_infrastructure"
+  network_id = kaleido_platform_network.ipfsnet_og.id
+}
+
 resource "kaleido_platform_network" "besunet_og" {
   provider = kaleido.originator
   type = "BesuNetwork"
@@ -102,6 +119,7 @@ resource "kaleido_platform_runtime" "bnr_signer_net_og" {
   environment = kaleido_platform_environment.env_og.id
   config_json = jsonencode({})
   count = var.originator_signer_count
+  stack_id = kaleido_platform_stack.chain_infra_besu_stack_og.id
 }
 
 resource "kaleido_platform_service" "bns_signer_net_og" {
@@ -118,6 +136,7 @@ resource "kaleido_platform_service" "bns_signer_net_og" {
   })
   count = var.originator_signer_count
   force_delete = true
+  stack_id = kaleido_platform_stack.chain_infra_besu_stack_og.id
 }
 
 resource "kaleido_platform_runtime" "bnr_peer_net_og" {
@@ -128,6 +147,7 @@ resource "kaleido_platform_runtime" "bnr_peer_net_og" {
   zone = var.originator_peer_network_dz
   config_json = jsonencode({})
   count = var.originator_peer_count
+  stack_id = kaleido_platform_stack.chain_infra_besu_stack_og.id
 }
 
 resource "kaleido_platform_service" "bns_peer_net_og" {
@@ -143,6 +163,7 @@ resource "kaleido_platform_service" "bns_peer_net_og" {
     signer = false
   })
   count = var.originator_peer_count
+  stack_id = kaleido_platform_stack.chain_infra_besu_stack_og.id
 }
 
 resource "kaleido_platform_runtime" "gwr_net_og" {
@@ -152,6 +173,7 @@ resource "kaleido_platform_runtime" "gwr_net_og" {
   environment = kaleido_platform_environment.env_og.id
   config_json = jsonencode({})
   count = var.originator_gateway_count
+  stack_id = kaleido_platform_stack.chain_infra_besu_stack_og.id
 }
 
 
@@ -167,6 +189,7 @@ resource "kaleido_platform_service" "gws_net_og" {
     }
   })
   count = var.originator_gateway_count
+  stack_id = kaleido_platform_stack.chain_infra_besu_stack_og.id
 }
 
 data "kaleido_platform_network_bootstrap_data" "net_og_bootstrap" {
@@ -188,6 +211,7 @@ resource "kaleido_platform_runtime" "inr_net_og" {
   zone = var.originator_peer_network_dz
   environment = kaleido_platform_environment.env_og.id
   config_json = jsonencode({ })
+  stack_id = kaleido_platform_stack.chain_infra_ipfs_stack_og.id
 }
 
 resource "kaleido_platform_service" "ins_net_og" {
@@ -202,10 +226,26 @@ resource "kaleido_platform_service" "ins_net_og" {
       id = kaleido_platform_network.ipfsnet_og.id
     }
   })
+  stack_id = kaleido_platform_stack.chain_infra_ipfs_stack_og.id
 }
 
 
 // Environment 2 - another member of the testnets joining
+resource "kaleido_platform_stack" "chain_infra_besu_stack_j1" {
+  provider = kaleido.originator
+  environment = kaleido_platform_environment.env_og.id
+  name = "chain_infra_besu_stack"
+  type = "chain_infrastructure"
+  network_id = kaleido_platform_network.besunet_j1.id
+}
+
+resource "kaleido_platform_stack" "chain_infra_ipfs_stack_j1" {
+  provider = kaleido.originator
+  environment = kaleido_platform_environment.env_og.id
+  name = "chain_infra_ipfs_stack"
+  type = "chain_infrastructure"
+  network_id = kaleido_platform_network.ipfsnet_j1.id
+}
 
 resource "kaleido_platform_environment" "env_j1" {
   provider = kaleido.joiner_one
@@ -245,6 +285,7 @@ resource "kaleido_platform_runtime" "bnr_peer_net_j1" {
   config_json = jsonencode({})
   count = var.joiner_one_peer_count
   depends_on = [kaleido_platform_network.besunet_j1]
+  stack_id = kaleido_platform_stack.chain_infra_besu_stack_j1.id
 }
 
 resource "kaleido_platform_service" "bns_peer_net_j1" {
@@ -260,22 +301,24 @@ resource "kaleido_platform_service" "bns_peer_net_j1" {
     signer = false
   })
   count = var.joiner_one_peer_count
+  stack_id = kaleido_platform_stack.chain_infra_besu_stack_j1.id
 }
 
 resource "kaleido_platform_runtime" "gwr_net_j1" {
   provider = kaleido.joiner_one
   type = "EVMGateway"
-  name = "${var.originator_name}_gateway"
+  name = "${var.joiner_one_name}_gateway"
   environment = kaleido_platform_environment.env_j1.id
   config_json = jsonencode({})
   depends_on = [kaleido_platform_network.besunet_j1]
   count = var.joiner_one_gateway_count
+  stack_id = kaleido_platform_stack.chain_infra_besu_stack_j1.id
 }
 
 resource "kaleido_platform_service" "gws_net_j1" {
   provider = kaleido.joiner_one
   type = "EVMGateway"
-  name = "${var.originator_name}_gateway"
+  name = "${var.joiner_one_name}_gateway"
   environment = kaleido_platform_environment.env_j1.id
   runtime = kaleido_platform_runtime.gwr_net_j1[count.index].id
   config_json = jsonencode({
@@ -284,6 +327,7 @@ resource "kaleido_platform_service" "gws_net_j1" {
     }
   })
   count = var.joiner_one_gateway_count
+  stack_id = kaleido_platform_stack.chain_infra_besu_stack_j1.id
 }
 
 resource "kaleido_platform_runtime" "inr_net_j1" {
@@ -294,6 +338,7 @@ resource "kaleido_platform_runtime" "inr_net_j1" {
   zone = var.joiner_one_peer_network_dz
   environment = kaleido_platform_environment.env_j1.id
   config_json = jsonencode({ })
+  stack_id = kaleido_platform_stack.chain_infra_ipfs_stack_j1.id
 }
 
 resource "kaleido_platform_service" "ins_net_j1" {
@@ -308,9 +353,26 @@ resource "kaleido_platform_service" "ins_net_j1" {
       id = kaleido_platform_network.ipfsnet_j1.id
     }
   })
+  stack_id = kaleido_platform_stack.chain_infra_ipfs_stack_j1.id
 }
 
 // Environment 3 - another member of the testnets joining
+resource "kaleido_platform_stack" "chain_infra_besu_stack_j2" {
+  provider = kaleido.originator
+  environment = kaleido_platform_environment.env_og.id
+  name = "chain_infra_besu_stack"
+  type = "chain_infrastructure"
+  network_id = kaleido_platform_network.besunet_j1.id
+}
+
+resource "kaleido_platform_stack" "chain_infra_ipfs_stack_j2" {
+  provider = kaleido.originator
+  environment = kaleido_platform_environment.env_og.id
+  name = "chain_infra_ipfs_stack"
+  type = "chain_infrastructure"
+  network_id = kaleido_platform_network.ipfsnet_j1.id
+}
+
 
 resource "kaleido_platform_environment" "env_j2" {
   provider = kaleido.joiner_two
@@ -350,6 +412,7 @@ resource "kaleido_platform_runtime" "bnr_peer_net_j2" {
   config_json = jsonencode({})
   count = var.joiner_two_peer_count
   depends_on = [kaleido_platform_network.besunet_j2]
+  stack_id = kaleido_platform_stack.chain_infra_besu_stack_j2.id
 }
 
 resource "kaleido_platform_service" "bns_peer_net_j2" {
@@ -365,22 +428,24 @@ resource "kaleido_platform_service" "bns_peer_net_j2" {
     signer = false
   })
   count = var.joiner_two_peer_count
+  stack_id = kaleido_platform_stack.chain_infra_besu_stack_j2.id
 }
 
 resource "kaleido_platform_runtime" "gwr_net_j2" {
   provider = kaleido.joiner_two
   type = "EVMGateway"
-  name = "${var.originator_name}_gateway"
+  name = "${var.joiner_two_name}_gateway"
   environment = kaleido_platform_environment.env_j2.id
   config_json = jsonencode({})
   depends_on = [kaleido_platform_network.besunet_j2]
   count = var.joiner_two_gateway_count
+  stack_id = kaleido_platform_stack.chain_infra_besu_stack_j2.id
 }
 
 resource "kaleido_platform_service" "gws_net_j2" {
   provider = kaleido.joiner_two
   type = "EVMGateway"
-  name = "${var.originator_name}_gateway"
+  name = "${var.joiner_two_name}_gateway"
   environment = kaleido_platform_environment.env_j2.id
   runtime = kaleido_platform_runtime.gwr_net_j2[count.index].id
   config_json = jsonencode({
@@ -389,6 +454,7 @@ resource "kaleido_platform_service" "gws_net_j2" {
     }
   })
   count = var.joiner_two_gateway_count
+  stack_id = kaleido_platform_stack.chain_infra_besu_stack_j2.id
 }
 
 resource "kaleido_platform_runtime" "inr_net_j2" {
@@ -399,6 +465,7 @@ resource "kaleido_platform_runtime" "inr_net_j2" {
   zone = var.joiner_two_peer_network_dz
   environment = kaleido_platform_environment.env_j2.id
   config_json = jsonencode({ })
+  stack_id = kaleido_platform_stack.chain_infra_ipfs_stack_j2.id
 }
 
 resource "kaleido_platform_service" "ins_net_j2" {
@@ -413,6 +480,7 @@ resource "kaleido_platform_service" "ins_net_j2" {
       id = kaleido_platform_network.ipfsnet_j2.id
     }
   })
+  stack_id = kaleido_platform_stack.chain_infra_ipfs_stack_j2.id
 }
 
 // Besu Network Connectors

--- a/examples/platform_multiaccountenv_testnets/main.tf
+++ b/examples/platform_multiaccountenv_testnets/main.tf
@@ -190,6 +190,7 @@ resource "kaleido_platform_runtime" "inr_net_og" {
 
   type = "IPFSNode"
   name = var.originator_name
+  zone = var.originator_peer_network_dz
   environment = kaleido_platform_environment.env_og.id
   config_json = jsonencode({ })
 }
@@ -295,6 +296,7 @@ resource "kaleido_platform_runtime" "inr_net_j1" {
 
   type = "IPFSNode"
   name = var.joiner_one_name
+  zone = var.joiner_one_peer_network_dz
   environment = kaleido_platform_environment.env_j1.id
   config_json = jsonencode({ })
 }
@@ -399,6 +401,7 @@ resource "kaleido_platform_runtime" "inr_net_j2" {
 
   type = "IPFSNode"
   name = var.joiner_two_name
+  zone = var.joiner_two_peer_network_dz
   environment = kaleido_platform_environment.env_j2.id
   config_json = jsonencode({ })
 }
@@ -466,7 +469,7 @@ resource "kaleido_network_connector" "besunet_og_connector_j2" {
 }
 
 resource "kaleido_network_connector" "besunet_j2_connector_og" {
-  provider = kaleido.originator
+  provider = kaleido.joiner_two
   type = "Platform"
   name = "${var.joiner_two_name}_conn_${var.originator_name}"
   environment = kaleido_platform_environment.env_j2.id

--- a/examples/platform_multiaccountenv_testnets/variables.tf
+++ b/examples/platform_multiaccountenv_testnets/variables.tf
@@ -1,0 +1,117 @@
+
+variable "besu_testnet_name" {
+    type = string
+    default = "testnet"
+}
+
+variable "ipfs_testnet_name" {
+    type = string
+    default = "filenet"
+}
+
+variable "originator_api_url" {
+  type = string
+}
+
+variable "originator_api_key_name" {
+  type = string
+}
+
+variable "originator_api_key_value" {
+  type = string
+}
+
+variable "joiner_one_api_url" {
+  type = string
+}
+
+variable "joiner_one_api_key_name" {
+  type = string
+}
+
+variable "joiner_one_api_key_value" {
+  type = string
+}
+
+variable "joiner_two_api_url" {
+  type = string
+}
+
+variable "joiner_two_api_key_name" {
+  type = string
+}
+
+variable "joiner_two_api_key_value" {
+  type = string
+}
+
+variable "originator_name" {
+  type = string
+}
+
+variable "joiner_one_name" {
+  type = string
+}
+
+variable "joiner_two_name" {
+  type = string
+}
+
+variable "originator_signer_count" {
+  type = number
+  default = 1
+}
+
+variable "originator_peer_count" {
+  type = number
+  default = 1
+}
+
+variable "joiner_one_peer_count" {
+  type = number
+  default = 1
+}
+
+variable "joiner_two_peer_count" {
+  type = number
+  default = 1
+}
+
+variable "originator_peer_network_dz" {
+  type = string
+}
+
+variable "joiner_one_peer_network_dz" {
+  type = string
+}
+
+variable "joiner_two_peer_network_dz" {
+  type = string
+}
+
+variable "originator_gateway_count" {
+  type = number
+  default = 1
+  validation {
+    condition = contains([0, 1], var.originator_gateway_count)
+    error_message = "Valid values for originator_gateway_count are (0, 1)"
+  }
+}
+
+variable "joiner_one_gateway_count" {
+  type = number
+  default = 1
+  validation {
+    condition = contains([0, 1], var.joiner_one_gateway_count)
+    error_message = "Valid values for joiner_one_gateway_count are (0, 1)"
+  }
+}
+
+variable "joiner_two_gateway_count" {
+  type = number
+  default = 1
+  validation {
+    condition = contains([0, 1], var.joiner_two_gateway_count)
+    error_message = "Valid values for joiner_two_gateway_count are (0, 1)"
+  }
+}

--- a/examples/platform_two_account_besu_network/README.md
+++ b/examples/platform_two_account_besu_network/README.md
@@ -1,0 +1,16 @@
+## platform_two_account_besu_network
+
+This module creates a shared Besu QBFT testnet across two different accounts in one or more Kaleido platform instances.
+It leverages `Permitted` network connectors to allow the  node identities and connectivity endpoints to be trusted between
+the two parties. It assumes the zones being used are enabled to a network connectivity plugin that allows for external
+IP addresses to be attached to node runtimes.
+
+**NOTE**: please contact Kaleido support to ensure you have runtimes zones with such network connectivity enabled. If
+you are running the Kaleido platform instance as software, please consult the software documentation for how you can
+configure, and even build, your own network connectivity plugins.
+
+This represents how to create a shared network across multiple accounts in different Kaleido platform instances, possibly
+in different regions or cloud providers.
+
+**NOTE**: network connectors are experimental and must be enabled on your Kaleido platform instance. Please contact
+support if you would like to use this feature.

--- a/examples/platform_two_account_besu_network/main.tf
+++ b/examples/platform_two_account_besu_network/main.tf
@@ -224,35 +224,31 @@ resource "kaleido_platform_service" "gws_net_sec" {
 resource "kaleido_network_connector" "net_sec_connector" {
   provider = kaleido.secondary
   type = "Platform"
-  name = "${var.secondary_name}_conn"
+  name = "${var.secondary_name}_conn_${var.originator_name}"
   environment = kaleido_platform_environment.env_sec.id
   network = kaleido_platform_network.net_sec.id
   zone = var.secondary_peer_network_dz
 
-  platform = {
+  platform_requestor = {
     target_account_id = data.kaleido_platform_account.acct_og.account_id
     target_environment_id = kaleido_platform_environment.env_og.id
     target_network_id = kaleido_platform_network.net_og.id
   }
-
-  depends_on = [kaleido_platform_network.net_sec, kaleido_platform_service.bns_peer_net_og]
 }
 
 
 resource "kaleido_network_connector" "net_og_connector" {
   provider = kaleido.originator
   type = "Platform"
-  name = "${var.originator_name}_conn"
+  name = "${var.originator_name}_conn_${var.secondary_name}"
   environment = kaleido_platform_environment.env_og.id
   network = kaleido_platform_network.net_og.id
   zone = var.originator_peer_network_dz
 
-  platform = {
+  platform_acceptor = {
     target_account_id = data.kaleido_platform_account.acct_sec.account_id
     target_environment_id = kaleido_platform_environment.env_sec.id
     target_network_id = kaleido_platform_network.net_sec.id
     target_connector_id = kaleido_network_connector.net_sec_connector.id
   }
-
-  depends_on = [kaleido_platform_network.net_og, kaleido_platform_service.bns_peer_net_sec]
 }

--- a/examples/platform_two_account_besu_network/main.tf
+++ b/examples/platform_two_account_besu_network/main.tf
@@ -14,19 +14,11 @@ provider "kaleido" {
   platform_password = var.originator_api_key_value
 }
 
-data "kaleido_platform_account" "acct_og" {
-    provider = kaleido.originator
-}
-
 provider "kaleido" {
   alias = "secondary"
   platform_api = var.secondary_api_url
   platform_username = var.secondary_api_key_name
   platform_password = var.secondary_api_key_value
-}
-
-data "kaleido_platform_account" "acct_sec" {
-  provider = kaleido.secondary
 }
 
 // Environment 1 - the originator of the network
@@ -223,32 +215,23 @@ resource "kaleido_platform_service" "gws_net_sec" {
 // Network Connectors
 resource "kaleido_network_connector" "net_sec_connector" {
   provider = kaleido.secondary
-  type = "Platform"
-  name = "${var.secondary_name}_conn_${var.originator_name}"
+  type = "Permitted"
+  name = "${var.secondary_name}_conn"
   environment = kaleido_platform_environment.env_sec.id
   network = kaleido_platform_network.net_sec.id
   zone = var.secondary_peer_network_dz
-
-  platform_requestor = {
-    target_account_id = data.kaleido_platform_account.acct_og.account_id
-    target_environment_id = kaleido_platform_environment.env_og.id
-    target_network_id = kaleido_platform_network.net_og.id
-  }
+  permitted_json = jsonencode({ peers = [ for peer in resource.kaleido_platform_service.bns_peer_net_og : jsondecode(peer.connectivity_json) ] })
+  depends_on = [kaleido_platform_network.net_sec, kaleido_platform_service.bns_peer_net_og]
 }
 
 
 resource "kaleido_network_connector" "net_og_connector" {
   provider = kaleido.originator
-  type = "Platform"
-  name = "${var.originator_name}_conn_${var.secondary_name}"
+  type = "Permitted"
+  name = "${var.originator_name}_conn"
   environment = kaleido_platform_environment.env_og.id
   network = kaleido_platform_network.net_og.id
   zone = var.originator_peer_network_dz
-
-  platform_acceptor = {
-    target_account_id = data.kaleido_platform_account.acct_sec.account_id
-    target_environment_id = kaleido_platform_environment.env_sec.id
-    target_network_id = kaleido_platform_network.net_sec.id
-    target_connector_id = kaleido_network_connector.net_sec_connector.id
-  }
+  permitted_json = jsonencode({ peers = [ for peer in resource.kaleido_platform_service.bns_peer_net_sec : jsondecode(peer.connectivity_json) ] })
+  depends_on = [kaleido_platform_network.net_og, kaleido_platform_service.bns_peer_net_sec]
 }

--- a/kaleido/kaleidobase/providerdata.go
+++ b/kaleido/kaleidobase/providerdata.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
+	"net"
 	"net/http"
 	"os"
 	"time"
@@ -92,8 +93,24 @@ func NewProviderData(logCtx context.Context, conf *ProviderModel) *ProviderData 
 	if platformPassword == "" {
 		platformPassword = os.Getenv("KALEIDO_PASSWORD")
 	}
+
+	// mostly the default settings, barring less conns to avoid concurrency limits w/in the Platform
+	platformHttp := &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+		DialContext: (&net.Dialer{
+			Timeout:   30 * time.Second,
+			KeepAlive: 30 * time.Second,
+		}).DialContext,
+		ForceAttemptHTTP2:     true,
+		MaxIdleConns:          5,
+		MaxConnsPerHost:       5,
+		MaxIdleConnsPerHost:   5,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   5 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+	}
 	platform := resty.New().
-		SetTransport(http.DefaultTransport).
+		SetTransport(platformHttp).
 		SetHeader("User-Agent", fmt.Sprintf("Terraform / %s (Platform)", version)).
 		AddRetryCondition(func(r *resty.Response, err error) bool {
 			if err != nil {

--- a/kaleido/platform/account.go
+++ b/kaleido/platform/account.go
@@ -15,11 +15,12 @@ package platform
 
 import (
 	"context"
+	"net/http"
+
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"net/http"
 )
 
 type AccountDatasourceModel struct {
@@ -28,7 +29,6 @@ type AccountDatasourceModel struct {
 
 type SelfIdentityAPIModel struct {
 	AccountID string `json:"accountId,omitempty"`
-	IsAdmin   bool   `json:"isAdmin,omitempty"`
 }
 
 func (m SelfIdentityAPIModel) toData(_ context.Context, s *AccountDatasourceModel, d *diag.Diagnostics) {

--- a/kaleido/platform/account.go
+++ b/kaleido/platform/account.go
@@ -1,0 +1,68 @@
+package platform
+
+import (
+	"context"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"net/http"
+)
+
+type AccountDatasourceModel struct {
+	AccountID types.String `tfsdk:"account_id"`
+}
+
+type SelfIdentityAPIModel struct {
+	AccountID string `json:"accountId,omitempty"`
+	IsAdmin   bool   `json:"isAdmin,omitempty"`
+}
+
+func (m SelfIdentityAPIModel) toData(_ context.Context, s *AccountDatasourceModel, d *diag.Diagnostics) {
+	if m.AccountID != "" {
+		s.AccountID = types.StringValue(m.AccountID)
+	} else {
+		d.AddError("AccountDatasourceModel", "Account ID is not set")
+	}
+}
+
+func AccountDatasourceModelFactory() datasource.DataSource {
+	return &AccountDatasource{}
+}
+
+type AccountDatasource struct {
+	commonDataSource
+}
+
+func (s AccountDatasource) Metadata(ctx context.Context, _ datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = "kaleido_platform_account"
+}
+
+func (s AccountDatasource) Schema(ctx context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"account_id": &schema.StringAttribute{
+				Computed: true,
+			},
+		},
+	}
+}
+
+func (r *AccountDatasource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var data AccountDatasourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+
+	var api SelfIdentityAPIModel
+
+	ok, status := r.apiRequest(ctx, http.MethodGet, "/api/v1/self/identity", nil, &api, &resp.Diagnostics, Allow404())
+	if !ok {
+		return
+	}
+	if status == 404 {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
+	api.toData(ctx, &data, &resp.Diagnostics)
+	resp.Diagnostics.Append(resp.State.Set(ctx, data)...)
+}

--- a/kaleido/platform/account.go
+++ b/kaleido/platform/account.go
@@ -1,3 +1,16 @@
+// Copyright © Kaleido, Inc. 2025
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package platform
 
 import (

--- a/kaleido/platform/account_test.go
+++ b/kaleido/platform/account_test.go
@@ -1,0 +1,57 @@
+// Copyright © Kaleido, Inc. 2025
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package platform
+
+import (
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"net/http"
+	"testing"
+)
+
+var accountDataStep1 = `
+data "kaleido_platform_account" "account" {}
+`
+
+func TestAccountData(t *testing.T) {
+	mp, providerConfig := testSetup(t)
+	defer func() {
+		mp.checkClearCalls([]string{
+			"GET /api/v1/self/identity", // read for initial state
+			"GET /api/v1/self/identity", // get data
+			"GET /api/v1/self/identity", // read for destroy / final state
+		})
+		mp.server.Close()
+	}()
+
+	accountData := "data.kaleido_platform_account.account"
+	resource.Test(t, resource.TestCase{
+		IsUnitTest:               true,
+		ProtoV6ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: providerConfig + accountDataStep1,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(accountData, "account_id", "an-account"),
+				),
+			},
+		},
+	})
+}
+
+func (mp *mockPlatform) getSelfIdentity(res http.ResponseWriter, req *http.Request) {
+	sid := &SelfIdentityAPIModel{
+		AccountID: "an-account",
+	}
+	mp.respond(res, sid, 200)
+}

--- a/kaleido/platform/common.go
+++ b/kaleido/platform/common.go
@@ -345,6 +345,7 @@ func DataSources() []func() datasource.DataSource {
 	return []func() datasource.DataSource{
 		EVMNetInfoDataSourceFactory,
 		NetworkBootstrapDatasourceModelFactory,
+		AccountDatasourceModelFactory,
 	}
 }
 

--- a/kaleido/platform/mockserver_test.go
+++ b/kaleido/platform/mockserver_test.go
@@ -1,4 +1,4 @@
-// Copyright © Kaleido, Inc. 2024
+// Copyright © Kaleido, Inc. 2024-2025
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -95,6 +95,10 @@ func startMockPlatformServer(t *testing.T) *mockPlatform {
 		router:            mux.NewRouter(),
 		calls:             []string{},
 	}
+
+	// See account_test.go
+	mp.register("/api/v1/self/identity", http.MethodGet, mp.getSelfIdentity)
+
 	// See environment_test.go
 	mp.register("/api/v1/environments", http.MethodPost, mp.postEnvironment)
 	mp.register("/api/v1/environments/{env}", http.MethodGet, mp.getEnvironment)
@@ -119,7 +123,7 @@ func startMockPlatformServer(t *testing.T) *mockPlatform {
 	mp.register("/api/v1/environments/{env}/networks/{network}", http.MethodPut, mp.putNetwork)
 	mp.register("/api/v1/environments/{env}/networks/{network}", http.MethodDelete, mp.deleteNetwork)
 
-	// See connector_test.go
+	// See network_connector_test.go
 	mp.register("/api/v1/environments/{env}/networks/{net}/connectors", http.MethodPost, mp.postConnector)
 	mp.register("/api/v1/environments/{env}/networks/{net}/connectors/{connector}", http.MethodGet, mp.getConnector)
 	mp.register("/api/v1/environments/{env}/networks/{net}/connectors/{connector}", http.MethodPut, mp.putConnector)

--- a/kaleido/platform/network_connector.go
+++ b/kaleido/platform/network_connector.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
 	"net/http"
 	"strings"
 	"time"
@@ -113,7 +114,8 @@ func (r *connectorResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 				Optional: true,
 			},
 			"platform_requestor": &schema.SingleNestedAttribute{
-				Optional: true,
+				Optional:      true,
+				PlanModifiers: []planmodifier.Object{objectplanmodifier.RequiresReplace()},
 				// TODO change should require a recreate
 				Attributes: map[string]schema.Attribute{
 					"target_account_id": &schema.StringAttribute{
@@ -131,7 +133,8 @@ func (r *connectorResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 				},
 			},
 			"platform_acceptor": &schema.SingleNestedAttribute{
-				Optional: true,
+				Optional:      true,
+				PlanModifiers: []planmodifier.Object{objectplanmodifier.RequiresReplace()},
 				// TODO change should require a recreate
 				Attributes: map[string]schema.Attribute{
 					"target_account_id": &schema.StringAttribute{

--- a/kaleido/platform/network_connector.go
+++ b/kaleido/platform/network_connector.go
@@ -113,6 +113,7 @@ func (r *connectorResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 			},
 			"platform_requestor": &schema.SingleNestedAttribute{
 				Optional: true,
+				// TODO change should require a recreate
 				Attributes: map[string]schema.Attribute{
 					"target_account_id": &schema.StringAttribute{
 						Required: true,
@@ -130,6 +131,7 @@ func (r *connectorResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 			},
 			"platform_acceptor": &schema.SingleNestedAttribute{
 				Optional: true,
+				// TODO change should require a recreate
 				Attributes: map[string]schema.Attribute{
 					"target_account_id": &schema.StringAttribute{
 						Required: true,

--- a/kaleido/platform/network_connector.go
+++ b/kaleido/platform/network_connector.go
@@ -17,10 +17,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
 	"net/http"
 	"strings"
 	"time"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -116,7 +117,6 @@ func (r *connectorResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 			"platform_requestor": &schema.SingleNestedAttribute{
 				Optional:      true,
 				PlanModifiers: []planmodifier.Object{objectplanmodifier.RequiresReplace()},
-				// TODO change should require a recreate
 				Attributes: map[string]schema.Attribute{
 					"target_account_id": &schema.StringAttribute{
 						Required: true,
@@ -135,7 +135,6 @@ func (r *connectorResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 			"platform_acceptor": &schema.SingleNestedAttribute{
 				Optional:      true,
 				PlanModifiers: []planmodifier.Object{objectplanmodifier.RequiresReplace()},
-				// TODO change should require a recreate
 				Attributes: map[string]schema.Attribute{
 					"target_account_id": &schema.StringAttribute{
 						Required: true,


### PR DESCRIPTION
## New Features

`data.kaleido_platform_account` for discovering the account ID of the API key + platform host in-use.

Support for the `type = "Platform"` of network connectors, allowing for requestors and acceptors to peer their disparate networks together if running within the same instance.

Adds connection limits and retry backoff to API calls for when platform 429's are encountered.

## New Examples

`platform_multiaccountenvs_testnets` uses the new `Platform` network connectors to demonstrate how to create a 3 member testnet of Besu and IPFS, with the originator acting as the bridge for the two joiner.