### PR TITLE
[resty] [retry] Retry-After w/ Jitter Support and Slower Status Checks

### DIFF
--- a/kaleido/kaleidobase/providerdata.go
+++ b/kaleido/kaleidobase/providerdata.go
@@ -17,9 +17,11 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
+	"math/rand/v2"
 	"net"
 	"net/http"
 	"os"
+	"strconv"
 	"time"
 
 	"github.com/go-resty/resty/v2"
@@ -121,9 +123,16 @@ func NewProviderData(logCtx context.Context, conf *ProviderModel) *ProviderData 
 			}
 			return false
 		}).
-		SetRetryCount(3).
-		SetRetryWaitTime(1 * time.Second).
-		SetRetryMaxWaitTime(10 * time.Second).
+		SetRetryCount(5).
+		SetRetryAfter(func(c *resty.Client, r *resty.Response) (time.Duration, error) {
+			tflog.Debug(logCtx, fmt.Sprintf("retryAfter: %s", r.Header().Get("Retry-After")))
+			retryAfter, err := strconv.ParseFloat(r.Header().Get("Retry-After"), 64)
+			if err != nil {
+				return 1 * time.Second, err
+			}
+			jitter := time.Duration(rand.NormFloat64() * float64(5*time.Second)) // up to 5 second random jitter to account for 5 concurrent connections all retrying up to 5 times
+			return time.Duration(retryAfter*float64(time.Second)) + jitter, nil
+		}).
 		SetBaseURL(platformAPI)
 	if platformUsername != "" && platformPassword != "" {
 		platform = platform.SetBasicAuth(platformUsername, platformPassword)

--- a/kaleido/kaleidobase/providerdata.go
+++ b/kaleido/kaleidobase/providerdata.go
@@ -126,9 +126,9 @@ func NewProviderData(logCtx context.Context, conf *ProviderModel) *ProviderData 
 		SetRetryCount(5).
 		SetRetryAfter(func(c *resty.Client, r *resty.Response) (time.Duration, error) {
 			tflog.Debug(logCtx, fmt.Sprintf("retryAfter: %s", r.Header().Get("Retry-After")))
-			retryAfter, err := strconv.ParseFloat(r.Header().Get("Retry-After"), 64)
+			retryAfter, err := strconv.ParseFloat(r.Header().Get("Retry-After"), 64) // decimal seconds
 			if err != nil {
-				return 1 * time.Second, err
+				retryAfter = 1.0
 			}
 			jitter := time.Duration(rand.NormFloat64() * float64(5*time.Second)) // up to 5 second random jitter to account for 5 concurrent connections all retrying up to 5 times
 			return time.Duration(retryAfter*float64(time.Second)) + jitter, nil

--- a/kaleido/kaleidobase/retry.go
+++ b/kaleido/kaleidobase/retry.go
@@ -29,8 +29,8 @@ type CustomRetry struct {
 }
 
 var Retry = &CustomRetry{
-	InitialDelay: 500 * time.Millisecond,
-	MaximumDelay: 5 * time.Second,
+	InitialDelay: 5 * time.Second,
+	MaximumDelay: 30 * time.Second,
 	Factor:       2.0,
 }
 


### PR DESCRIPTION
For ExtraSmall runtimes with conservative rate limits - we need to retry much more slowly.

For general HTTP requests we use the `Retry-After` header if present, or just 1s, with random jitter up to 5s, to retry 429s.

For resources that use `Retry` to check the status of a resource before marking it completed (contract builds/actions, FireFly registrations, etc.) - we slow down the retry factor significantly, and add code to try to treat explicit 429 errors as retries.