### PR TITLE
allow wallet updates and including creds

### DIFF
--- a/kaleido/platform/kms_wallet_test.go
+++ b/kaleido/platform/kms_wallet_test.go
@@ -69,7 +69,7 @@ func TestKMSWallet1(t *testing.T) {
 			"GET /endpoint/{env}/{service}/rest/api/v1/wallets/{wallet}",
 			"GET /endpoint/{env}/{service}/rest/api/v1/wallets/{wallet}",
 			"GET /endpoint/{env}/{service}/rest/api/v1/wallets/{wallet}",
-			"PUT /endpoint/{env}/{service}/rest/api/v1/wallets/{wallet}",
+			"PATCH /endpoint/{env}/{service}/rest/api/v1/wallets/{wallet}",
 			"GET /endpoint/{env}/{service}/rest/api/v1/wallets/{wallet}",
 			"DELETE /endpoint/{env}/{service}/rest/api/v1/wallets/{wallet}",
 			"GET /endpoint/{env}/{service}/rest/api/v1/wallets/{wallet}",
@@ -154,8 +154,8 @@ func (mp *mockPlatform) postKMSWallet(res http.ResponseWriter, req *http.Request
 	mp.respond(res, &obj, 201)
 }
 
-func (mp *mockPlatform) putKMSWallet(res http.ResponseWriter, req *http.Request) {
-	obj := mp.kmsWallets[mux.Vars(req)["env"]+"/"+mux.Vars(req)["service"]+"/"+mux.Vars(req)["wallet"]] // expected behavior of provider is PUT only on exists
+func (mp *mockPlatform) patchKMSWallet(res http.ResponseWriter, req *http.Request) {
+	obj := mp.kmsWallets[mux.Vars(req)["env"]+"/"+mux.Vars(req)["service"]+"/"+mux.Vars(req)["wallet"]] // expected behavior of provider is PATCH only on exists
 	assert.NotNil(mp.t, obj)
 	var newObj KMSWalletAPIModel
 	mp.getBody(req, &newObj)

--- a/kaleido/platform/mockserver_test.go
+++ b/kaleido/platform/mockserver_test.go
@@ -137,7 +137,7 @@ func startMockPlatformServer(t *testing.T) *mockPlatform {
 	// See kms_wallet.go
 	mp.register("/endpoint/{env}/{service}/rest/api/v1/wallets", http.MethodPost, mp.postKMSWallet)
 	mp.register("/endpoint/{env}/{service}/rest/api/v1/wallets/{wallet}", http.MethodGet, mp.getKMSWallet)
-	mp.register("/endpoint/{env}/{service}/rest/api/v1/wallets/{wallet}", http.MethodPut, mp.putKMSWallet)
+	mp.register("/endpoint/{env}/{service}/rest/api/v1/wallets/{wallet}", http.MethodPatch, mp.patchKMSWallet)
 	mp.register("/endpoint/{env}/{service}/rest/api/v1/wallets/{wallet}", http.MethodDelete, mp.deleteKMSWallet)
 
 	// See kms_key.go


### PR DESCRIPTION
Fix bug where wallet v1 API updates are `PATCH` not `PUT`.
Also be credentials aware on update, to allow update of credentials for those wallet types that permit it.

Tested from starting on previous release, creating wallets, then updating those with this branch validating that:
- updates apply on a wallet update correctly
- state retained so future updates don't reattempt should there be no change in the plan
- update can also update credentials on wallet types that support it

Note - credentials (when specified) now get correctly retained in terraform state to support this because GET and POST apis don't return any associated credentials, this is to prevent PATCH attempts when the plan has not changed.

So no migration needed, but it would be possible for a HD wallet that was created with a mnemonic that wasn't retained in the plan state, to continue to try to update (which isn't supported). But this behaviour would already occur on the current release and also it would fail earlier as it would try to PUT not PATCH. So edge case but some manual remedying might be needed in such cases once this version is picked up.