### PR TITLE
Revert PR #154: remove kaleido_platform_service import support

### DIFF
--- a/kaleido/platform/service.go
+++ b/kaleido/platform/service.go
@@ -18,7 +18,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"strings"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
@@ -371,23 +370,9 @@ func (data *ServiceResourceModel) toAPI(ctx context.Context, api *ServiceAPIMode
 
 func (api *ServiceAPIModel) toData(data *ServiceResourceModel, diagnostics *diag.Diagnostics) {
 	data.ID = types.StringValue(api.ID)
-	data.Type = types.StringValue(api.Type)
-	data.Name = types.StringValue(api.Name)
-	data.StackID = types.StringValue(api.StackID)
 	data.EnvironmentMemberID = types.StringValue(api.EnvironmentMemberID)
-	if api.Runtime.ID != "" {
-		data.Runtime = types.StringValue(api.Runtime.ID)
-	}
 	if api.DatabaseName != "" {
 		data.DatabaseName = types.StringValue(api.DatabaseName)
-	}
-	if api.Config != nil {
-		configBytes, err := json.Marshal(api.Config)
-		if err != nil {
-			diagnostics.AddError("failed to marshal config", err.Error())
-		} else {
-			data.ConfigJSON = types.StringValue(string(configBytes))
-		}
 	}
 	endpoints := map[string]attr.Value{}
 	endpointAttrTypes := map[string]attr.Type{
@@ -528,26 +513,4 @@ func (r *serviceResource) Delete(ctx context.Context, req resource.DeleteRequest
 	_, _ = r.apiRequest(ctx, http.MethodDelete, r.apiPath(&data), nil, nil, &resp.Diagnostics, Allow404())
 
 	r.waitForRemoval(ctx, r.apiPath(&data), &resp.Diagnostics)
-}
-
-// ImportState supports ID-based import. Use environment_id/stack_id/service_id (all IDs, not names).
-// Two-part format environment_id/service_id is also supported; stack_id will be filled from the API on first Read.
-func (r *serviceResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	parts := strings.SplitN(req.ID, "/", 3)
-	switch len(parts) {
-	case 2:
-		// environment_id/service_id
-		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("environment"), parts[0])...)
-		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), parts[1])...)
-	case 3:
-		// environment_id/stack_id/service_id
-		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("environment"), parts[0])...)
-		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("stack_id"), parts[1])...)
-		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), parts[2])...)
-	default:
-		resp.Diagnostics.AddError(
-			"invalid import id",
-			"import id must be environment_id/service_id or environment_id/stack_id/service_id (all IDs, not names)",
-		)
-	}
 }

--- a/kaleido/platform/service_test.go
+++ b/kaleido/platform/service_test.go
@@ -17,7 +17,6 @@ import (
 	"fmt"
 	"net/http"
 	"regexp"
-	"strings"
 	"testing"
 	"time"
 
@@ -242,81 +241,8 @@ func TestService1(t *testing.T) {
 	})
 }
 
-// TestServiceImportIDFormat tests ID-based import with environment_id/stack_id/service_id.
-func TestServiceImportIDFormat(t *testing.T) {
-	mp, providerConfig := testSetup(t)
-	defer func() {
-		mp.server.Close()
-	}()
-
-	// Pre-seed service so Read after import can fetch it
-	existingID := "imported-svc-id"
-	now := time.Now().UTC()
-	mp.services["env1/"+existingID] = &ServiceAPIModel{
-		ID:                  existingID,
-		Type:                "BesuNodeService",
-		Name:                "besu-node30",
-		StackID:             "st:14dsbcszcw",
-		Created:             &now,
-		Updated:             &now,
-		Status:              "ready",
-		EnvironmentMemberID: "mem1",
-		Runtime:             ServiceAPIRuntimeRef{ID: "runtime1"},
-		Config:              map[string]interface{}{"key": "value"},
-		Endpoints: map[string]ServiceAPIEndpoint{
-			"api": {Type: "http", URLS: []string{"https://example.com/api/v1/environments/env1/services/" + existingID}},
-		},
-		StatusDetails: ServiceStatusDetails{
-			Connectivity: &Connectivity{Identity: "test"},
-		},
-	}
-
-	config := `
-resource "kaleido_platform_service" "imported" {
-    environment = "env1"
-    runtime     = "runtime1"
-    type        = "BesuNodeService"
-    name        = "besu-node30"
-    stack_id    = "st:14dsbcszcw"
-    config_json = jsonencode({})
-}
-`
-	resource.Test(t, resource.TestCase{
-		IsUnitTest:               true,
-		ProtoV6ProviderFactories: testAccProviders,
-		Steps: []resource.TestStep{
-			{
-				Config:            providerConfig + config,
-				ResourceName:      "kaleido_platform_service.imported",
-				ImportState:       true,
-				ImportStateId:     "env1/st:14dsbcszcw/" + existingID,
-				ImportStateVerify: false,
-				ImportStateCheck: func(s []*terraform.InstanceState) error {
-					assert.Len(t, s, 1)
-					assert.Equal(t, existingID, s[0].Attributes["id"])
-					assert.Equal(t, "env1", s[0].Attributes["environment"])
-					assert.Equal(t, "st:14dsbcszcw", s[0].Attributes["stack_id"])
-					assert.Equal(t, "BesuNodeService", s[0].Attributes["type"])
-					assert.Equal(t, "besu-node30", s[0].Attributes["name"])
-					return nil
-				},
-			},
-		},
-	})
-}
 func (mp *mockPlatform) getService(res http.ResponseWriter, req *http.Request) {
-	env := mux.Vars(req)["env"]
-	serviceKey := mux.Vars(req)["service"]
-	svc := mp.services[env+"/"+serviceKey]
-	if svc == nil {
-		// Resolve by name for import
-		for key, s := range mp.services {
-			if strings.HasPrefix(key, env+"/") && s.Name == serviceKey {
-				svc = s
-				break
-			}
-		}
-	}
+	svc := mp.services[mux.Vars(req)["env"]+"/"+mux.Vars(req)["service"]]
 	if svc == nil {
 		mp.respond(res, nil, 404)
 	} else {
@@ -342,7 +268,6 @@ func (mp *mockPlatform) getService(res http.ResponseWriter, req *http.Request) {
 func (mp *mockPlatform) postService(res http.ResponseWriter, req *http.Request) {
 	var svc ServiceAPIModel
 	mp.getBody(req, &svc)
-	env := mux.Vars(req)["env"]
 	svc.ID = nanoid.New()
 	now := time.Now().UTC()
 	svc.Created = &now
@@ -352,10 +277,10 @@ func (mp *mockPlatform) postService(res http.ResponseWriter, req *http.Request) 
 	svc.Endpoints = map[string]ServiceAPIEndpoint{
 		"api": {
 			Type: "http",
-			URLS: []string{fmt.Sprintf("https://example.com/api/v1/environments/%s/services/%s", env, svc.ID)},
+			URLS: []string{fmt.Sprintf("https://example.com/api/v1/environments/%s/services/%s", mux.Vars(req)["env"], svc.ID)},
 		},
 	}
-	mp.services[env+"/"+svc.ID] = &svc
+	mp.services[mux.Vars(req)["env"]+"/"+svc.ID] = &svc
 	mp.respond(res, &svc, 201)
 }
 


### PR DESCRIPTION
Undoes the changes from merge 6c17f0a (import state, toData fields for import/read, and related tests/mock behavior) on top of the current branch.