### PR TITLE
feat(connector_flow): version Parameter for pinning and drift detection

### DIFF
--- a/docs/resources/platform_connector_flow.md
+++ b/docs/resources/platform_connector_flow.md
@@ -25,6 +25,7 @@ Deploys a connector flow (workflow template) from a connector service's embedded
 
 - `config_type_bindings` (Map of String) Map of config type name to config profile name-or-ID. Each entry binds a config type referenced by the flow to a concrete config profile.
 - `description` (String) Optional description override for the deployed workflow.
+- `version` (String) Template version to pin the deployed flow to. A connector service can only deploy the template version embedded in its current image, so this acts as an expectation: changing it triggers an upgrade of the deployed flow, and the apply fails if the service deploys a different version than requested. If omitted, the flow tracks whatever version the service deploys.
 
 ### Read-Only
 

--- a/kaleido/platform/connector_flow.go
+++ b/kaleido/platform/connector_flow.go
@@ -239,10 +239,9 @@ func (r *connectorFlowResource) Update(ctx context.Context, req resource.UpdateR
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	// Use /upgrade which accepts the same configTypeBindings and is idempotent on the
-	// current template version. The connector-manager merges bindings server-side.
-	// See .ai/plan.md for the open question on whether to switch to PATCH for
-	// binding-only edits once that's verified end-to-end.
+	// Use /upgrade, which moves the flow to the template version embedded in the
+	// running connector image (no version can be requested; downgrades are rejected
+	// server-side and same-version is an early-return no-op).
 	body := ConnectorFlowUpgradeAPIModel{ConfigTypeBindings: bindings}
 	var api ConnectorFlowAPIModel
 	ok, _ := r.apiRequest(ctx, http.MethodPost, r.metadataPath(&data, "/upgrade"), &body, &api, &resp.Diagnostics)

--- a/kaleido/platform/connector_flow.go
+++ b/kaleido/platform/connector_flow.go
@@ -35,6 +35,7 @@ type ConnectorFlowResourceModel struct {
 	Name               types.String `tfsdk:"name"`
 	Description        types.String `tfsdk:"description"`
 	ConfigTypeBindings types.Map    `tfsdk:"config_type_bindings"`
+	Version            types.String `tfsdk:"version"`
 	FlowType           types.String `tfsdk:"flow_type"`
 	CurrentVersion     types.String `tfsdk:"current_version"`
 }
@@ -109,6 +110,11 @@ func (r *connectorFlowResource) Schema(_ context.Context, _ resource.SchemaReque
 					mapplanmodifier.UseStateForUnknown(),
 				},
 			},
+			"version": &schema.StringAttribute{
+				Optional:    true,
+				Computed:    true,
+				Description: "Template version to pin the deployed flow to. A connector service can only deploy the template version embedded in its current image, so this acts as an expectation: changing it triggers an upgrade of the deployed flow, and the apply fails if the service deploys a different version than requested. If omitted, the flow tracks whatever version the service deploys.",
+			},
 			"flow_type": &schema.StringAttribute{
 				Computed:    true,
 				Description: "The flow type as reported by the deployed workflow (e.g. submission, query).",
@@ -155,6 +161,22 @@ func (r *connectorFlowResource) toData(api *ConnectorFlowAPIModel, data *Connect
 	}
 	data.FlowType = types.StringValue(api.FlowType)
 	data.CurrentVersion = types.StringValue(api.CurrentVersion)
+	// `version` always reflects the deployed version, so out-of-band upgrades
+	// surface as a plan diff against a pinned config value.
+	data.Version = types.StringValue(api.CurrentVersion)
+}
+
+// A connector service can only deploy the template version embedded in its image, so
+// `version` is verified after deploy/upgrade rather than sent to the API.
+func (r *connectorFlowResource) checkVersionPin(requested types.String, api *ConnectorFlowAPIModel, diagnostics *diag.Diagnostics) {
+	if requested.IsNull() || requested.IsUnknown() || requested.ValueString() == api.CurrentVersion {
+		return
+	}
+	diagnostics.AddError(
+		"Connector flow version mismatch",
+		fmt.Sprintf("Requested version %q of connector flow %q, but the connector service deployed version %q. The service deploys only the template version embedded in its current image — upgrade the connector service to an image that embeds %q, or change `version` to %q.",
+			requested.ValueString(), api.Name, api.CurrentVersion, requested.ValueString(), api.CurrentVersion),
+	)
 }
 
 func (r *connectorFlowResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
@@ -179,8 +201,12 @@ func (r *connectorFlowResource) Create(ctx context.Context, req resource.CreateR
 	if !ok {
 		return
 	}
+	requestedVersion := data.Version
 	r.toData(&api, &data)
+	// Set state even on a version mismatch so the deployed flow is tracked (and
+	// re-created on the next apply) rather than orphaned.
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+	r.checkVersionPin(requestedVersion, &api, &resp.Diagnostics)
 }
 
 func (r *connectorFlowResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
@@ -223,8 +249,11 @@ func (r *connectorFlowResource) Update(ctx context.Context, req resource.UpdateR
 	if !ok {
 		return
 	}
+	requestedVersion := data.Version
 	r.toData(&api, &data)
+	// Record the actual deployed version even when it doesn't match the pin.
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+	r.checkVersionPin(requestedVersion, &api, &resp.Diagnostics)
 }
 
 func (r *connectorFlowResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {

--- a/kaleido/platform/connector_flow_test.go
+++ b/kaleido/platform/connector_flow_test.go
@@ -1,0 +1,202 @@
+// Copyright © Kaleido, Inc. 2026
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package platform
+
+import (
+	"net/http"
+	"regexp"
+	"testing"
+
+	"github.com/gorilla/mux"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+var connector_flow_unpinned = `
+resource "kaleido_platform_connector_flow" "submission" {
+  environment = "test-env"
+  service     = "test-service"
+  name        = "submission"
+  config_type_bindings = {
+    "evm.gasPricing" = "evm.gasPricing"
+  }
+}
+`
+
+var connector_flow_pinned_current = `
+resource "kaleido_platform_connector_flow" "submission" {
+  environment = "test-env"
+  service     = "test-service"
+  name        = "submission"
+  version     = "2026.03.0"
+  config_type_bindings = {
+    "evm.gasPricing" = "evm.gasPricing"
+  }
+}
+`
+
+var connector_flow_pinned_next = `
+resource "kaleido_platform_connector_flow" "submission" {
+  environment = "test-env"
+  service     = "test-service"
+  name        = "submission"
+  version     = "2026.04.0"
+  config_type_bindings = {
+    "evm.gasPricing" = "evm.gasPricing"
+  }
+}
+`
+
+func TestConnectorFlowUnpinned(t *testing.T) {
+	mp, providerConfig := testSetup(t)
+	defer func() {
+		mp.checkClearCalls([]string{
+			"POST /endpoint/{env}/{service}/rest/api/v1/metadata/connector-flows/{flow}/deploy",
+			"GET /endpoint/{env}/{service}/rest/api/v1/connector-flows/{flow}",
+			"DELETE /endpoint/{env}/{service}/rest/api/v1/connector-flows/{flow}",
+		})
+		mp.server.Close()
+	}()
+
+	res := "kaleido_platform_connector_flow.submission"
+	resource.Test(t, resource.TestCase{
+		IsUnitTest:               true,
+		ProtoV6ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: providerConfig + connector_flow_unpinned,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet(res, "id"),
+					resource.TestCheckResourceAttr(res, "flow_type", "submission"),
+					resource.TestCheckResourceAttr(res, "version", "2026.03.0"),
+					resource.TestCheckResourceAttr(res, "current_version", "2026.03.0"),
+				),
+			},
+		},
+	})
+}
+
+func TestConnectorFlowPinnedUpgrade(t *testing.T) {
+	mp, providerConfig := testSetup(t)
+	defer func() {
+		mp.checkClearCalls([]string{
+			"POST /endpoint/{env}/{service}/rest/api/v1/metadata/connector-flows/{flow}/deploy",
+			"GET /endpoint/{env}/{service}/rest/api/v1/connector-flows/{flow}",
+			"GET /endpoint/{env}/{service}/rest/api/v1/connector-flows/{flow}",
+			"POST /endpoint/{env}/{service}/rest/api/v1/metadata/connector-flows/{flow}/upgrade",
+			"GET /endpoint/{env}/{service}/rest/api/v1/connector-flows/{flow}",
+			"DELETE /endpoint/{env}/{service}/rest/api/v1/connector-flows/{flow}",
+		})
+		mp.server.Close()
+	}()
+
+	res := "kaleido_platform_connector_flow.submission"
+	resource.Test(t, resource.TestCase{
+		IsUnitTest:               true,
+		ProtoV6ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: providerConfig + connector_flow_pinned_current,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(res, "version", "2026.03.0"),
+					resource.TestCheckResourceAttr(res, "current_version", "2026.03.0"),
+				),
+			},
+			{
+				// The connector service image has been upgraded and now embeds a newer
+				// template; bumping the pin drives the /upgrade.
+				PreConfig: func() { mp.connectorFlowTemplateVersion = "2026.04.0" },
+				Config:    providerConfig + connector_flow_pinned_next,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(res, "version", "2026.04.0"),
+					resource.TestCheckResourceAttr(res, "current_version", "2026.04.0"),
+				),
+			},
+		},
+	})
+}
+
+func TestConnectorFlowPinMismatch(t *testing.T) {
+	mp, providerConfig := testSetup(t)
+	defer func() {
+		mp.checkClearCalls([]string{
+			"POST /endpoint/{env}/{service}/rest/api/v1/metadata/connector-flows/{flow}/deploy",
+			"DELETE /endpoint/{env}/{service}/rest/api/v1/connector-flows/{flow}",
+		})
+		mp.server.Close()
+	}()
+
+	resource.Test(t, resource.TestCase{
+		IsUnitTest:               true,
+		ProtoV6ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				// The mock service only embeds 2026.03.0, so pinning 2026.04.0 fails.
+				Config:      providerConfig + connector_flow_pinned_next,
+				ExpectError: regexp.MustCompile(`Connector flow version mismatch`),
+			},
+		},
+	})
+}
+
+// Mock server handlers
+
+func (mp *mockPlatform) connectorFlowKey(vars map[string]string) string {
+	return vars["env"] + "/" + vars["service"] + "/" + vars["flow"]
+}
+
+func (mp *mockPlatform) deployConnectorFlow(res http.ResponseWriter, req *http.Request) {
+	vars := mux.Vars(req)
+	var body ConnectorFlowDeployAPIModel
+	mp.getBody(req, &body)
+	flow := &ConnectorFlowAPIModel{
+		ID:             "wfl:" + vars["flow"],
+		Name:           vars["flow"],
+		FlowType:       vars["flow"],
+		CurrentVersion: mp.connectorFlowTemplateVersion,
+		Description:    body.Description,
+	}
+	mp.connectorFlows[mp.connectorFlowKey(vars)] = flow
+	mp.respond(res, flow, http.StatusOK)
+}
+
+func (mp *mockPlatform) upgradeConnectorFlow(res http.ResponseWriter, req *http.Request) {
+	vars := mux.Vars(req)
+	flow := mp.connectorFlows[mp.connectorFlowKey(vars)]
+	if flow == nil {
+		mp.respond(res, nil, http.StatusNotFound)
+		return
+	}
+	flow.CurrentVersion = mp.connectorFlowTemplateVersion
+	mp.respond(res, flow, http.StatusOK)
+}
+
+func (mp *mockPlatform) getConnectorFlow(res http.ResponseWriter, req *http.Request) {
+	flow := mp.connectorFlows[mp.connectorFlowKey(mux.Vars(req))]
+	if flow == nil {
+		mp.respond(res, nil, http.StatusNotFound)
+		return
+	}
+	mp.respond(res, flow, http.StatusOK)
+}
+
+func (mp *mockPlatform) deleteConnectorFlow(res http.ResponseWriter, req *http.Request) {
+	vars := mux.Vars(req)
+	key := mp.connectorFlowKey(vars)
+	if mp.connectorFlows[key] == nil {
+		mp.respond(res, nil, http.StatusNotFound)
+		return
+	}
+	delete(mp.connectorFlows, key)
+	mp.respond(res, nil, http.StatusNoContent)
+}

--- a/kaleido/platform/mockserver_test.go
+++ b/kaleido/platform/mockserver_test.go
@@ -83,56 +83,61 @@ type mockPlatform struct {
 	fireflyContractListeners    map[string]*FireFlyContractListenerAPIModel
 	fireflySubscriptions        map[string]*FireFlySubscriptionAPIModel
 	connectorFlowConfigBindings map[string]*ConnectorFlowConfigBindingAPIModel
+	connectorFlows              map[string]*ConnectorFlowAPIModel
+	// The template version the mock service "embeds" — deploy/upgrade always land here.
+	connectorFlowTemplateVersion string
 }
 
 func startMockPlatformServer(t *testing.T) *mockPlatform {
 	mp := &mockPlatform{
-		t:                           t,
-		environments:                make(map[string]*EnvironmentAPIModel),
-		runtimes:                    make(map[string]*RuntimeAPIModel),
-		services:                    make(map[string]*ServiceAPIModel),
-		networks:                    make(map[string]*NetworkAPIModel),
-		stacks:                      make(map[string]*StacksAPIModel),
-		connectors:                  make(map[string]*ConnectorAPIModel),
-		networkinitdatas:            make(map[string]*NetworkInitData),
-		kmsWallets:                  make(map[string]*KMSWalletAPIModel),
-		arsNamespaces:               make(map[string]*ARSNamespaceAPIModel),
-		kmsKeys:                     make(map[string]*KMSKeyAPIModel),
-		cmsBuilds:                   make(map[string]*CMSBuildAPIModel),
-		cmsActions:                  make(map[string]CMSActionAPIBaseAccessor),
-		amsTasks:                    make(map[string]*AMSTaskAPIModel),
-		amsTaskVersions:             make(map[string]map[string]interface{}),
-		amsPolicies:                 make(map[string]*AMSPolicyAPIModel),
-		amsPolicyVersions:           make(map[string]*AMSPolicyVersionAPIModel),
-		amsDMUpserts:                make(map[string]map[string]interface{}),
-		amsFFListeners:              make(map[string]*AMSFFListenerAPIModel),
-		amsDMListeners:              make(map[string]*AMSDMListenerAPIModel),
-		amsVariableSets:             make(map[string]*AMSVariableSetAPIModel),
-		amsCollections:              make(map[string]*AMSCollectionAPIModel),
-		groups:                      make(map[string]*GroupAPIModel),
-		applications:                make(map[string]*ApplicationAPIModel),
-		serviceAccess:               make(map[string]*ServiceAccessAPIModel),
-		serviceAccessPolicies:       make(map[string]*ServiceAccessPolicyAPIModel),
-		accountAccessPolicies:       make(map[string]*AccountAccessPolicyAPIModel),
-		stackAccess:                 make(map[string]*StackAccessAPIModel),
-		apiKeys:                     make(map[string]*APIKeyAPIModel),
-		wmsWallets:                  make(map[string]*WMSWalletAPIModel),
-		wmsAssets:                   make(map[string]*WMSAssetAPIModel),
-		wmsAssetIcons:               make(map[string]*struct{}),
-		wmsAccounts:                 make(map[string]*WMSAccountAPIModel),
-		policyIdentities:            make(map[string]*PolicyIdentityAPIModel),
-		pmsIdentityLists:            make(map[string]*PMSIdentityListAPIModel),
-		pmsIdentityListVersions:     make(map[string]map[string]*PMSIdentityListVersionAPIModel),
-		pmsPolicyDeployments:        make(map[string]*PMSPolicyDeploymentAPIModel),
-		pmsPolicyDeploymentVersions: make(map[string]map[string]*PMSPolicyDeploymentVersionAPIModel),
-		wfeWorkflows:                make(map[string]*WFEWorkflowAPIModel),
-		wfeWorkflowVersions:         make(map[string]map[string]*WFEWorkflowVersionAPIModel),
-		wfeStreams:                  make(map[string]*WFEStreamAPIModel),
-		wfeStreamFactories:          make(map[string]*WFEStreamFactoryAPIModel),
-		fireflyContractListeners:    make(map[string]*FireFlyContractListenerAPIModel),
-		fireflySubscriptions:        make(map[string]*FireFlySubscriptionAPIModel),
-		router:                      mux.NewRouter(),
-		calls:                       []string{},
+		t:                            t,
+		environments:                 make(map[string]*EnvironmentAPIModel),
+		runtimes:                     make(map[string]*RuntimeAPIModel),
+		services:                     make(map[string]*ServiceAPIModel),
+		networks:                     make(map[string]*NetworkAPIModel),
+		stacks:                       make(map[string]*StacksAPIModel),
+		connectors:                   make(map[string]*ConnectorAPIModel),
+		networkinitdatas:             make(map[string]*NetworkInitData),
+		kmsWallets:                   make(map[string]*KMSWalletAPIModel),
+		arsNamespaces:                make(map[string]*ARSNamespaceAPIModel),
+		kmsKeys:                      make(map[string]*KMSKeyAPIModel),
+		cmsBuilds:                    make(map[string]*CMSBuildAPIModel),
+		cmsActions:                   make(map[string]CMSActionAPIBaseAccessor),
+		amsTasks:                     make(map[string]*AMSTaskAPIModel),
+		amsTaskVersions:              make(map[string]map[string]interface{}),
+		amsPolicies:                  make(map[string]*AMSPolicyAPIModel),
+		amsPolicyVersions:            make(map[string]*AMSPolicyVersionAPIModel),
+		amsDMUpserts:                 make(map[string]map[string]interface{}),
+		amsFFListeners:               make(map[string]*AMSFFListenerAPIModel),
+		amsDMListeners:               make(map[string]*AMSDMListenerAPIModel),
+		amsVariableSets:              make(map[string]*AMSVariableSetAPIModel),
+		amsCollections:               make(map[string]*AMSCollectionAPIModel),
+		groups:                       make(map[string]*GroupAPIModel),
+		applications:                 make(map[string]*ApplicationAPIModel),
+		serviceAccess:                make(map[string]*ServiceAccessAPIModel),
+		serviceAccessPolicies:        make(map[string]*ServiceAccessPolicyAPIModel),
+		accountAccessPolicies:        make(map[string]*AccountAccessPolicyAPIModel),
+		stackAccess:                  make(map[string]*StackAccessAPIModel),
+		apiKeys:                      make(map[string]*APIKeyAPIModel),
+		wmsWallets:                   make(map[string]*WMSWalletAPIModel),
+		wmsAssets:                    make(map[string]*WMSAssetAPIModel),
+		wmsAssetIcons:                make(map[string]*struct{}),
+		wmsAccounts:                  make(map[string]*WMSAccountAPIModel),
+		policyIdentities:             make(map[string]*PolicyIdentityAPIModel),
+		pmsIdentityLists:             make(map[string]*PMSIdentityListAPIModel),
+		pmsIdentityListVersions:      make(map[string]map[string]*PMSIdentityListVersionAPIModel),
+		pmsPolicyDeployments:         make(map[string]*PMSPolicyDeploymentAPIModel),
+		pmsPolicyDeploymentVersions:  make(map[string]map[string]*PMSPolicyDeploymentVersionAPIModel),
+		wfeWorkflows:                 make(map[string]*WFEWorkflowAPIModel),
+		wfeWorkflowVersions:          make(map[string]map[string]*WFEWorkflowVersionAPIModel),
+		wfeStreams:                   make(map[string]*WFEStreamAPIModel),
+		wfeStreamFactories:           make(map[string]*WFEStreamFactoryAPIModel),
+		fireflyContractListeners:     make(map[string]*FireFlyContractListenerAPIModel),
+		fireflySubscriptions:         make(map[string]*FireFlySubscriptionAPIModel),
+		connectorFlows:               make(map[string]*ConnectorFlowAPIModel),
+		connectorFlowTemplateVersion: "2026.03.0",
+		router:                       mux.NewRouter(),
+		calls:                        []string{},
 	}
 
 	// See account_test.go
@@ -353,6 +358,12 @@ func startMockPlatformServer(t *testing.T) *mockPlatform {
 	mp.register("/api/v1/account-access/policies/{policy}", http.MethodDelete, mp.deleteAccountAccessPolicy)
 
 	// See connector_flow_config_binding_test.go
+	// See connector_flow_test.go
+	mp.register("/endpoint/{env}/{service}/rest/api/v1/metadata/connector-flows/{flow}/deploy", http.MethodPost, mp.deployConnectorFlow)
+	mp.register("/endpoint/{env}/{service}/rest/api/v1/metadata/connector-flows/{flow}/upgrade", http.MethodPost, mp.upgradeConnectorFlow)
+	mp.register("/endpoint/{env}/{service}/rest/api/v1/connector-flows/{flow}", http.MethodGet, mp.getConnectorFlow)
+	mp.register("/endpoint/{env}/{service}/rest/api/v1/connector-flows/{flow}", http.MethodDelete, mp.deleteConnectorFlow)
+
 	mp.register("/endpoint/{env}/{service}/rest/api/v1/connector-flows/{flow}/config-profile-bindings", http.MethodGet, mp.listConnectorFlowConfigBindings)
 	mp.register("/endpoint/{env}/{service}/rest/api/v1/connector-flows/{flow}/config-profile-bindings/{binding}", http.MethodGet, mp.getConnectorFlowConfigBinding)
 	mp.register("/endpoint/{env}/{service}/rest/api/v1/connector-flows/{flow}/config-profile-bindings/{binding}", http.MethodPatch, mp.patchConnectorFlowConfigBinding)


### PR DESCRIPTION
The flow API has `/upgrade` - but as noted by the comments this does not take in a version, because it only supports upgrading to the latest version embedded in the currently running connector.

`version` is therefore meant to 1) trigger calling `/upgrade`, and 2) help detect if there is drift between what the user intends/wants the version to be, and what it actually is.

Paired with https://github.com/kaleido-io/terraform-kaleido-modules - versions of the connector modules will be pinned to specific flow versions since they are 1:1 with Kaleido platform releases. The resulting UX is as follows:
1. Kaleido platform is upgraded to new version i.e. v26.X.0
2. Connector is upgraded once environment is upgraded, either if the environment is on automatic upgrade or on manual upgrade.
3. With a new connector version, a new version of the flow _may_ become available which is indicated in the new Terraform diff on a newer version of the module v26.X.0
4. If the module documents the new flow version for the corresponding connector version, the user upgrades and applies, it will then get on the expected version and confirm it.
5. If the user accidentally tries downgrading the version, upgrades to a module version newer than the connector they are using, the Terraform apply will fail indicating the version mismatch