### PR TITLE
Add custom plan modifier RequireRecreate

### DIFF
--- a/docs/resources/platform_kms_folder.md
+++ b/docs/resources/platform_kms_folder.md
@@ -3,12 +3,12 @@
 page_title: "kaleido_platform_kms_folder Resource - terraform-provider-kaleido"
 subcategory: ""
 description: |-
-  A folder within a KMS keystore, used to organise keys into a hierarchy. Folders cannot be renamed or moved after creation — changes require replacement. A folder cannot be deleted while it still contains keys or sub-folders.
+  A folder within a KMS keystore, used to organise keys into a hierarchy. Folders cannot be renamed or moved after creation — changes are not supported and require destroying and recreating the folder. A folder cannot be deleted while it still contains keys or sub-folders.
 ---
 
 # kaleido_platform_kms_folder (Resource)
 
-A folder within a KMS keystore, used to organise keys into a hierarchy. Folders cannot be renamed or moved after creation — changes require replacement. A folder cannot be deleted while it still contains keys or sub-folders.
+A folder within a KMS keystore, used to organise keys into a hierarchy. Folders cannot be renamed or moved after creation — changes are not supported and require destroying and recreating the folder. A folder cannot be deleted while it still contains keys or sub-folders.
 
 
 
@@ -17,14 +17,14 @@ A folder within a KMS keystore, used to organise keys into a hierarchy. Folders 
 
 ### Required
 
-- `environment` (String) Environment ID
-- `keystore` (String) Keystore (KMS Wallet) ID
-- `name` (String) Folder name
-- `service` (String) Key Manager Service ID
+- `environment` (String) Environment ID. Immutable after create — changing this value is not supported; destroy and recreate the folder instead.
+- `keystore` (String) Keystore (KMS Wallet) ID. Immutable after create — changing this value is not supported; destroy and recreate the folder instead.
+- `name` (String) Folder name. Immutable after create — changing this value is not supported; destroy and recreate the folder instead.
+- `service` (String) Key Manager Service ID. Immutable after create — changing this value is not supported; destroy and recreate the folder instead.
 
 ### Optional
 
-- `parent_folder_id` (String) ID of the parent folder. Omit to create a root-level folder.
+- `parent_folder_id` (String) ID of the parent folder. Omit to create a root-level folder. Immutable after create — changing this value is not supported; destroy and recreate the folder instead.
 
 ### Read-Only
 

--- a/docs/resources/platform_kms_folder.md
+++ b/docs/resources/platform_kms_folder.md
@@ -17,14 +17,14 @@ A folder within a KMS keystore, used to organise keys into a hierarchy. Folders 
 
 ### Required
 
-- `environment` (String) Environment ID. Immutable after create — changing this value is not supported; destroy and recreate the folder instead.
-- `keystore` (String) Keystore (KMS Wallet) ID. Immutable after create — changing this value is not supported; destroy and recreate the folder instead.
-- `name` (String) Folder name. Immutable after create — changing this value is not supported; destroy and recreate the folder instead.
-- `service` (String) Key Manager Service ID. Immutable after create — changing this value is not supported; destroy and recreate the folder instead.
+- `environment` (String) Environment ID. Immutable after create — changing this value is not supported; create a new, separate folder instead.
+- `keystore` (String) Keystore (KMS Wallet) ID. Immutable after create — changing this value is not supported; create a new, separate folder instead.
+- `name` (String) Folder name. Immutable after create — changing this value is not supported; create a new, separate folder instead.
+- `service` (String) Key Manager Service ID. Immutable after create — changing this value is not supported; create a new, separate folder instead.
 
 ### Optional
 
-- `parent_folder_id` (String) ID of the parent folder. Omit to create a root-level folder. Immutable after create — changing this value is not supported; destroy and recreate the folder instead.
+- `parent_folder_id` (String) ID of the parent folder. Omit to create a root-level folder. Immutable after create — changing this value is not supported; create a new, separate folder instead.
 
 ### Read-Only
 

--- a/docs/resources/platform_kms_key.md
+++ b/docs/resources/platform_kms_key.md
@@ -24,9 +24,9 @@ A reference to a signing key (also known as a key mapping) that is directly/indi
 
 ### Optional
 
-- `attributes` (Map of String) Optional attributes of the key for key creation.
+- `attributes` (Map of String) Optional attributes of the key for key creation. Immutable after create — changing this value is not supported; create a new, separate key instead.
 - `folder_path` (String) Slash-separated folder hierarchy to place this key in, e.g. "treasury" or "ops/hot". Folders are automatically created if they do not exist. Immutable after create — changing this value is not supported; create a new, separate key instead.
-- `path` (String) A unique identifier for a piece of key material that is understood by the associated signing technology for a wallet. Each key that exists must have a path to associate the key with the key material that is used for signing.
+- `path` (String) A unique identifier for a piece of key material that is understood by the associated signing technology for a wallet. Each key that exists must have a path to associate the key with the key material that is used for signing. Immutable after create — changing this value is not supported; create a new, separate key instead.
 - `public_identifier_types` (List of String) Optional public identifier types to create for the key.
 
 ### Read-Only

--- a/docs/resources/platform_kms_key.md
+++ b/docs/resources/platform_kms_key.md
@@ -17,15 +17,15 @@ A reference to a signing key (also known as a key mapping) that is directly/indi
 
 ### Required
 
-- `environment` (String) Environment ID. Immutable after create — changing this value is not supported; destroy and recreate the key instead.
+- `environment` (String) Environment ID. Immutable after create — changing this value is not supported; create a new, separate key instead.
 - `name` (String) Key Display Name
-- `service` (String) Key Manager Service ID. Immutable after create — changing this value is not supported; destroy and recreate the key instead.
-- `wallet` (String) Wallet ID. Immutable after create — changing this value is not supported; destroy and recreate the key instead.
+- `service` (String) Key Manager Service ID. Immutable after create — changing this value is not supported; create a new, separate key instead.
+- `wallet` (String) Wallet ID. Immutable after create — changing this value is not supported; create a new, separate key instead.
 
 ### Optional
 
 - `attributes` (Map of String) Optional attributes of the key for key creation.
-- `folder_path` (String) Slash-separated folder hierarchy to place this key in, e.g. "treasury" or "ops/hot". Folders are automatically created if they do not exist. Immutable after create — changing this value is not supported; destroy and recreate the key instead.
+- `folder_path` (String) Slash-separated folder hierarchy to place this key in, e.g. "treasury" or "ops/hot". Folders are automatically created if they do not exist. Immutable after create — changing this value is not supported; create a new, separate key instead.
 - `path` (String) A unique identifier for a piece of key material that is understood by the associated signing technology for a wallet. Each key that exists must have a path to associate the key with the key material that is used for signing.
 - `public_identifier_types` (List of String) Optional public identifier types to create for the key.
 

--- a/docs/resources/platform_kms_key.md
+++ b/docs/resources/platform_kms_key.md
@@ -17,15 +17,15 @@ A reference to a signing key (also known as a key mapping) that is directly/indi
 
 ### Required
 
-- `environment` (String) Environment ID
+- `environment` (String) Environment ID. Immutable after create — changing this value is not supported; destroy and recreate the key instead.
 - `name` (String) Key Display Name
-- `service` (String) Key Manager Service ID
-- `wallet` (String) Wallet ID
+- `service` (String) Key Manager Service ID. Immutable after create — changing this value is not supported; destroy and recreate the key instead.
+- `wallet` (String) Wallet ID. Immutable after create — changing this value is not supported; destroy and recreate the key instead.
 
 ### Optional
 
 - `attributes` (Map of String) Optional attributes of the key for key creation.
-- `folder_path` (String) Slash-separated folder hierarchy to place this key in, e.g. "treasury" or "ops/hot". Folders are automatically created if they do not exist. Changing this field requires key replacement.
+- `folder_path` (String) Slash-separated folder hierarchy to place this key in, e.g. "treasury" or "ops/hot". Folders are automatically created if they do not exist. Immutable after create — changing this value is not supported; destroy and recreate the key instead.
 - `path` (String) A unique identifier for a piece of key material that is understood by the associated signing technology for a wallet. Each key that exists must have a path to associate the key with the key material that is used for signing.
 - `public_identifier_types` (List of String) Optional public identifier types to create for the key.
 

--- a/docs/resources/platform_kms_key.md
+++ b/docs/resources/platform_kms_key.md
@@ -27,10 +27,10 @@ A reference to a signing key (also known as a key mapping) that is directly/indi
 - `attributes` (Map of String) Optional attributes of the key for key creation. Immutable after create — changing this value is not supported; create a new, separate key instead.
 - `folder_path` (String) Slash-separated folder hierarchy to place this key in, e.g. "treasury" or "ops/hot". Folders are automatically created if they do not exist. Immutable after create — changing this value is not supported; create a new, separate key instead.
 - `path` (String) A unique identifier for a piece of key material that is understood by the associated signing technology for a wallet. Each key that exists must have a path to associate the key with the key material that is used for signing. Immutable after create — changing this value is not supported; create a new, separate key instead.
-- `public_identifier_types` (List of String) Optional public identifier types to create for the key.
+- `public_identifier_types` (List of String) Optional public identifier types to create for the key. Applied only at create — immutable after create; changing this value is not supported; create a new, separate key instead.
 
 ### Read-Only
 
 - `address` (String)
 - `id` (String) The ID of this resource.
-- `uri` (String) The canonical URI of the key, assigned by the server after creation.
+- `uri` (String) The canonical URI of the key, assigned by the server after creation. Updates when the key is renamed.

--- a/kaleido/planmodifiers/require_recreate.go
+++ b/kaleido/planmodifiers/require_recreate.go
@@ -69,11 +69,10 @@ func (m requireRecreateModifier) PlanModifyString(ctx context.Context, req planm
 		"Immutable attribute cannot be updated",
 		fmt.Sprintf(
 			"Changing %q on an existing %s is not supported, and automatic resource replace is disabled for this attribute.\n\n"+
-				"To use a different value, destroy the existing resource and create a new one, for example:\n"+
-				"  terraform destroy -target=<this resource>\n"+
-				"  terraform apply\n\n"+
+				"To use a different value, create a new, separate %s instead.\n\n"+
 				"Prior value: %s\nProposed value: %s",
 			attr,
+			resourceLabel,
 			resourceLabel,
 			stringValueForDiag(req.StateValue.IsNull(), req.StateValue.ValueString()),
 			stringValueForDiag(req.PlanValue.IsNull(), req.PlanValue.ValueString()),

--- a/kaleido/planmodifiers/require_recreate.go
+++ b/kaleido/planmodifiers/require_recreate.go
@@ -1,4 +1,4 @@
-// Copyright © Kaleido, Inc. 2024-2026
+// Copyright © Kaleido, Inc. 2026
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,7 +17,10 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
 // RequireRecreate returns a string plan modifier that rejects changes to an
@@ -28,44 +31,88 @@ import (
 // resourceType should be the Terraform type name (e.g. "kaleido_platform_kms_key")
 // used in diagnostic messages.
 func RequireRecreate(resourceType string) planmodifier.String {
-	return requireRecreateModifier{resourceType: resourceType}
+	return requireRecreateStringModifier{resourceType: resourceType}
 }
 
-type requireRecreateModifier struct {
+// RequireRecreateMap is the map-attribute equivalent of RequireRecreate.
+func RequireRecreateMap(resourceType string) planmodifier.Map {
+	return requireRecreateMapModifier{resourceType: resourceType}
+}
+
+type requireRecreateStringModifier struct {
 	resourceType string
 }
 
-func (m requireRecreateModifier) Description(_ context.Context) string {
-	return "If the value of this attribute changes after create, planning fails because replace is not supported; destroy and recreate the resource instead."
+func (m requireRecreateStringModifier) Description(_ context.Context) string {
+	return requireRecreateDescription
 }
 
-func (m requireRecreateModifier) MarkdownDescription(ctx context.Context) string {
+func (m requireRecreateStringModifier) MarkdownDescription(ctx context.Context) string {
 	return m.Description(ctx)
 }
 
-func (m requireRecreateModifier) PlanModifyString(ctx context.Context, req planmodifier.StringRequest, resp *planmodifier.StringResponse) {
-	// Creating the resource — allow any value.
-	if req.State.Raw.IsNull() {
+func (m requireRecreateStringModifier) PlanModifyString(ctx context.Context, req planmodifier.StringRequest, resp *planmodifier.StringResponse) {
+	addRequireRecreateErrorIfChanged(
+		req.State.Raw.IsNull(),
+		req.PlanValue.IsUnknown() || req.StateValue.IsUnknown(),
+		req.PlanValue.Equal(req.StateValue),
+		req.Path,
+		m.resourceType,
+		stringValueForDiag(req.StateValue.IsNull(), req.StateValue.ValueString()),
+		stringValueForDiag(req.PlanValue.IsNull(), req.PlanValue.ValueString()),
+		&resp.Diagnostics,
+	)
+}
+
+type requireRecreateMapModifier struct {
+	resourceType string
+}
+
+func (m requireRecreateMapModifier) Description(_ context.Context) string {
+	return requireRecreateDescription
+}
+
+func (m requireRecreateMapModifier) MarkdownDescription(ctx context.Context) string {
+	return m.Description(ctx)
+}
+
+func (m requireRecreateMapModifier) PlanModifyMap(ctx context.Context, req planmodifier.MapRequest, resp *planmodifier.MapResponse) {
+	addRequireRecreateErrorIfChanged(
+		req.State.Raw.IsNull(),
+		req.PlanValue.IsUnknown() || req.StateValue.IsUnknown(),
+		req.PlanValue.Equal(req.StateValue),
+		req.Path,
+		m.resourceType,
+		mapValueForDiag(req.StateValue),
+		mapValueForDiag(req.PlanValue),
+		&resp.Diagnostics,
+	)
+}
+
+const requireRecreateDescription = "If the value of this attribute changes after create, planning fails because replace is not supported; create a new resource instead."
+
+func addRequireRecreateErrorIfChanged(
+	creating bool,
+	unknown bool,
+	equal bool,
+	attrPath path.Path,
+	resourceType string,
+	priorValue string,
+	proposedValue string,
+	diagnostics *diag.Diagnostics,
+) {
+	if creating || unknown || equal {
 		return
 	}
 
-	// Nothing to compare yet (e.g. unknown until apply).
-	if req.PlanValue.IsUnknown() || req.StateValue.IsUnknown() {
-		return
-	}
-
-	if req.PlanValue.Equal(req.StateValue) {
-		return
-	}
-
-	resourceLabel := m.resourceType
+	resourceLabel := resourceType
 	if resourceLabel == "" {
 		resourceLabel = "resource"
 	}
 
-	attr := req.Path.String()
-	resp.Diagnostics.AddAttributeError(
-		req.Path,
+	attr := attrPath.String()
+	diagnostics.AddAttributeError(
+		attrPath,
 		"Immutable attribute cannot be updated",
 		fmt.Sprintf(
 			"Changing %q on an existing %s is not supported, and automatic resource replace is disabled for this attribute.\n\n"+
@@ -74,8 +121,8 @@ func (m requireRecreateModifier) PlanModifyString(ctx context.Context, req planm
 			attr,
 			resourceLabel,
 			resourceLabel,
-			stringValueForDiag(req.StateValue.IsNull(), req.StateValue.ValueString()),
-			stringValueForDiag(req.PlanValue.IsNull(), req.PlanValue.ValueString()),
+			priorValue,
+			proposedValue,
 		),
 	)
 }
@@ -85,4 +132,11 @@ func stringValueForDiag(isNull bool, value string) string {
 		return "(null)"
 	}
 	return value
+}
+
+func mapValueForDiag(value types.Map) string {
+	if value.IsNull() {
+		return "(null)"
+	}
+	return value.String()
 }

--- a/kaleido/planmodifiers/require_recreate.go
+++ b/kaleido/planmodifiers/require_recreate.go
@@ -1,0 +1,89 @@
+// Copyright © Kaleido, Inc. 2024-2026
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package planmodifiers
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+)
+
+// RequireRecreate returns a string plan modifier that rejects changes to an
+// attribute after the resource has been created. Unlike RequiresReplace, it does
+// not plan a destroy/create cycle — the plan fails and the user must destroy and
+// recreate the resource themselves.
+//
+// resourceType should be the Terraform type name (e.g. "kaleido_platform_kms_key")
+// used in diagnostic messages.
+func RequireRecreate(resourceType string) planmodifier.String {
+	return requireRecreateModifier{resourceType: resourceType}
+}
+
+type requireRecreateModifier struct {
+	resourceType string
+}
+
+func (m requireRecreateModifier) Description(_ context.Context) string {
+	return "If the value of this attribute changes after create, planning fails because replace is not supported; destroy and recreate the resource instead."
+}
+
+func (m requireRecreateModifier) MarkdownDescription(ctx context.Context) string {
+	return m.Description(ctx)
+}
+
+func (m requireRecreateModifier) PlanModifyString(ctx context.Context, req planmodifier.StringRequest, resp *planmodifier.StringResponse) {
+	// Creating the resource — allow any value.
+	if req.State.Raw.IsNull() {
+		return
+	}
+
+	// Nothing to compare yet (e.g. unknown until apply).
+	if req.PlanValue.IsUnknown() || req.StateValue.IsUnknown() {
+		return
+	}
+
+	if req.PlanValue.Equal(req.StateValue) {
+		return
+	}
+
+	resourceLabel := m.resourceType
+	if resourceLabel == "" {
+		resourceLabel = "resource"
+	}
+
+	attr := req.Path.String()
+	resp.Diagnostics.AddAttributeError(
+		req.Path,
+		"Immutable attribute cannot be updated",
+		fmt.Sprintf(
+			"Changing %q on an existing %s is not supported, and automatic resource replace is disabled for this attribute.\n\n"+
+				"To use a different value, destroy the existing resource and create a new one, for example:\n"+
+				"  terraform destroy -target=<this resource>\n"+
+				"  terraform apply\n\n"+
+				"Prior value: %s\nProposed value: %s",
+			attr,
+			resourceLabel,
+			stringValueForDiag(req.StateValue.IsNull(), req.StateValue.ValueString()),
+			stringValueForDiag(req.PlanValue.IsNull(), req.PlanValue.ValueString()),
+		),
+	)
+}
+
+func stringValueForDiag(isNull bool, value string) string {
+	if isNull {
+		return "(null)"
+	}
+	return value
+}

--- a/kaleido/planmodifiers/require_recreate.go
+++ b/kaleido/planmodifiers/require_recreate.go
@@ -39,6 +39,11 @@ func RequireRecreateMap(resourceType string) planmodifier.Map {
 	return requireRecreateMapModifier{resourceType: resourceType}
 }
 
+// RequireRecreateList is the list-attribute equivalent of RequireRecreate.
+func RequireRecreateList(resourceType string) planmodifier.List {
+	return requireRecreateListModifier{resourceType: resourceType}
+}
+
 type requireRecreateStringModifier struct {
 	resourceType string
 }
@@ -89,6 +94,31 @@ func (m requireRecreateMapModifier) PlanModifyMap(ctx context.Context, req planm
 	)
 }
 
+type requireRecreateListModifier struct {
+	resourceType string
+}
+
+func (m requireRecreateListModifier) Description(_ context.Context) string {
+	return requireRecreateDescription
+}
+
+func (m requireRecreateListModifier) MarkdownDescription(ctx context.Context) string {
+	return m.Description(ctx)
+}
+
+func (m requireRecreateListModifier) PlanModifyList(ctx context.Context, req planmodifier.ListRequest, resp *planmodifier.ListResponse) {
+	addRequireRecreateErrorIfChanged(
+		req.State.Raw.IsNull(),
+		req.PlanValue.IsUnknown() || req.StateValue.IsUnknown(),
+		req.PlanValue.Equal(req.StateValue),
+		req.Path,
+		m.resourceType,
+		listValueForDiag(req.StateValue),
+		listValueForDiag(req.PlanValue),
+		&resp.Diagnostics,
+	)
+}
+
 const requireRecreateDescription = "If the value of this attribute changes after create, planning fails because replace is not supported; create a new resource instead."
 
 func addRequireRecreateErrorIfChanged(
@@ -135,6 +165,13 @@ func stringValueForDiag(isNull bool, value string) string {
 }
 
 func mapValueForDiag(value types.Map) string {
+	if value.IsNull() {
+		return "(null)"
+	}
+	return value.String()
+}
+
+func listValueForDiag(value types.List) string {
 	if value.IsNull() {
 		return "(null)"
 	}

--- a/kaleido/planmodifiers/require_recreate_test.go
+++ b/kaleido/planmodifiers/require_recreate_test.go
@@ -61,17 +61,17 @@ func TestRequireRecreate_ErrorsOnChange(t *testing.T) {
 		State: tfsdk.State{Raw: tftypes.NewValue(tftypes.Object{
 			AttributeTypes: map[string]tftypes.Type{"name": tftypes.String},
 		}, map[string]tftypes.Value{
-			"name": tftypes.NewValue(tftypes.String, "hot"),
+			"name": tftypes.NewValue(tftypes.String, "name1"),
 		})},
-		StateValue: types.StringValue("hot"),
-		PlanValue:  types.StringValue("cold"),
+		StateValue: types.StringValue("name1"),
+		PlanValue:  types.StringValue("name2"),
 	}, &resp)
 
 	require.True(t, resp.Diagnostics.HasError())
 	assert.Contains(t, resp.Diagnostics.Errors()[0].Summary(), "Immutable attribute cannot be updated")
 	assert.Contains(t, resp.Diagnostics.Errors()[0].Detail(), "name")
 	assert.Contains(t, resp.Diagnostics.Errors()[0].Detail(), "kaleido_platform_kms_folder")
-	assert.Contains(t, resp.Diagnostics.Errors()[0].Detail(), "destroy")
+	assert.Contains(t, resp.Diagnostics.Errors()[0].Detail(), "create a new, separate")
 }
 
 func TestRequireRecreate_ErrorsOnNullToValue(t *testing.T) {

--- a/kaleido/planmodifiers/require_recreate_test.go
+++ b/kaleido/planmodifiers/require_recreate_test.go
@@ -118,3 +118,30 @@ func TestRequireRecreateMap_ErrorsOnChange(t *testing.T) {
 	assert.Contains(t, resp.Diagnostics.Errors()[0].Detail(), "attributes")
 	assert.Contains(t, resp.Diagnostics.Errors()[0].Detail(), "kaleido_platform_kms_key")
 }
+
+func TestRequireRecreateList_ErrorsOnChange(t *testing.T) {
+	var resp planmodifier.ListResponse
+	prior, diags := types.ListValueFrom(context.Background(), types.StringType, []string{"address_ethereum"})
+	require.False(t, diags.HasError())
+	proposed, diags := types.ListValueFrom(context.Background(), types.StringType, []string{"address_ethereum", "address_ethereum_checksum"})
+	require.False(t, diags.HasError())
+
+	RequireRecreateList("kaleido_platform_kms_key").PlanModifyList(context.Background(), planmodifier.ListRequest{
+		Path: path.Root("public_identifier_types"),
+		State: tfsdk.State{Raw: tftypes.NewValue(tftypes.Object{
+			AttributeTypes: map[string]tftypes.Type{
+				"public_identifier_types": tftypes.List{ElementType: tftypes.String},
+			},
+		}, map[string]tftypes.Value{
+			"public_identifier_types": tftypes.NewValue(tftypes.List{ElementType: tftypes.String}, []tftypes.Value{
+				tftypes.NewValue(tftypes.String, "address_ethereum"),
+			}),
+		})},
+		StateValue: prior,
+		PlanValue:  proposed,
+	}, &resp)
+
+	require.True(t, resp.Diagnostics.HasError())
+	assert.Contains(t, resp.Diagnostics.Errors()[0].Detail(), "public_identifier_types")
+	assert.Contains(t, resp.Diagnostics.Errors()[0].Detail(), "kaleido_platform_kms_key")
+}

--- a/kaleido/planmodifiers/require_recreate_test.go
+++ b/kaleido/planmodifiers/require_recreate_test.go
@@ -1,0 +1,93 @@
+// Copyright © Kaleido, Inc. 2024-2026
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package planmodifiers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRequireRecreate_AllowsCreate(t *testing.T) {
+	var resp planmodifier.StringResponse
+	RequireRecreate("kaleido_platform_kms_key").PlanModifyString(context.Background(), planmodifier.StringRequest{
+		Path:       path.Root("environment"),
+		State:      tfsdk.State{Raw: tftypes.NewValue(tftypes.Object{}, nil)},
+		StateValue: types.StringNull(),
+		PlanValue:  types.StringValue("env1"),
+	}, &resp)
+
+	assert.False(t, resp.Diagnostics.HasError())
+}
+
+func TestRequireRecreate_AllowsUnchanged(t *testing.T) {
+	var resp planmodifier.StringResponse
+	RequireRecreate("kaleido_platform_kms_key").PlanModifyString(context.Background(), planmodifier.StringRequest{
+		Path: path.Root("environment"),
+		State: tfsdk.State{Raw: tftypes.NewValue(tftypes.Object{
+			AttributeTypes: map[string]tftypes.Type{"environment": tftypes.String},
+		}, map[string]tftypes.Value{
+			"environment": tftypes.NewValue(tftypes.String, "env1"),
+		})},
+		StateValue: types.StringValue("env1"),
+		PlanValue:  types.StringValue("env1"),
+	}, &resp)
+
+	assert.False(t, resp.Diagnostics.HasError())
+}
+
+func TestRequireRecreate_ErrorsOnChange(t *testing.T) {
+	var resp planmodifier.StringResponse
+	RequireRecreate("kaleido_platform_kms_folder").PlanModifyString(context.Background(), planmodifier.StringRequest{
+		Path: path.Root("name"),
+		State: tfsdk.State{Raw: tftypes.NewValue(tftypes.Object{
+			AttributeTypes: map[string]tftypes.Type{"name": tftypes.String},
+		}, map[string]tftypes.Value{
+			"name": tftypes.NewValue(tftypes.String, "hot"),
+		})},
+		StateValue: types.StringValue("hot"),
+		PlanValue:  types.StringValue("cold"),
+	}, &resp)
+
+	require.True(t, resp.Diagnostics.HasError())
+	assert.Contains(t, resp.Diagnostics.Errors()[0].Summary(), "Immutable attribute cannot be updated")
+	assert.Contains(t, resp.Diagnostics.Errors()[0].Detail(), "name")
+	assert.Contains(t, resp.Diagnostics.Errors()[0].Detail(), "kaleido_platform_kms_folder")
+	assert.Contains(t, resp.Diagnostics.Errors()[0].Detail(), "destroy")
+}
+
+func TestRequireRecreate_ErrorsOnNullToValue(t *testing.T) {
+	var resp planmodifier.StringResponse
+	RequireRecreate("kaleido_platform_kms_folder").PlanModifyString(context.Background(), planmodifier.StringRequest{
+		Path: path.Root("parent_folder_id"),
+		State: tfsdk.State{Raw: tftypes.NewValue(tftypes.Object{
+			AttributeTypes: map[string]tftypes.Type{"parent_folder_id": tftypes.String},
+		}, map[string]tftypes.Value{
+			"parent_folder_id": tftypes.NewValue(tftypes.String, nil),
+		})},
+		StateValue: types.StringNull(),
+		PlanValue:  types.StringValue("kmf:abc"),
+	}, &resp)
+
+	require.True(t, resp.Diagnostics.HasError())
+	assert.Contains(t, resp.Diagnostics.Errors()[0].Detail(), "(null)")
+	assert.Contains(t, resp.Diagnostics.Errors()[0].Detail(), "kaleido_platform_kms_folder")
+}

--- a/kaleido/planmodifiers/require_recreate_test.go
+++ b/kaleido/planmodifiers/require_recreate_test.go
@@ -1,4 +1,4 @@
-// Copyright © Kaleido, Inc. 2024-2026
+// Copyright © Kaleido, Inc. 2026
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -90,4 +90,31 @@ func TestRequireRecreate_ErrorsOnNullToValue(t *testing.T) {
 	require.True(t, resp.Diagnostics.HasError())
 	assert.Contains(t, resp.Diagnostics.Errors()[0].Detail(), "(null)")
 	assert.Contains(t, resp.Diagnostics.Errors()[0].Detail(), "kaleido_platform_kms_folder")
+}
+
+func TestRequireRecreateMap_ErrorsOnChange(t *testing.T) {
+	var resp planmodifier.MapResponse
+	prior, diags := types.MapValueFrom(context.Background(), types.StringType, map[string]string{"a": "1"})
+	require.False(t, diags.HasError())
+	proposed, diags := types.MapValueFrom(context.Background(), types.StringType, map[string]string{"a": "2"})
+	require.False(t, diags.HasError())
+
+	RequireRecreateMap("kaleido_platform_kms_key").PlanModifyMap(context.Background(), planmodifier.MapRequest{
+		Path: path.Root("attributes"),
+		State: tfsdk.State{Raw: tftypes.NewValue(tftypes.Object{
+			AttributeTypes: map[string]tftypes.Type{
+				"attributes": tftypes.Map{ElementType: tftypes.String},
+			},
+		}, map[string]tftypes.Value{
+			"attributes": tftypes.NewValue(tftypes.Map{ElementType: tftypes.String}, map[string]tftypes.Value{
+				"attribute": tftypes.NewValue(tftypes.String, "1"),
+			}),
+		})},
+		StateValue: prior,
+		PlanValue:  proposed,
+	}, &resp)
+
+	require.True(t, resp.Diagnostics.HasError())
+	assert.Contains(t, resp.Diagnostics.Errors()[0].Detail(), "attributes")
+	assert.Contains(t, resp.Diagnostics.Errors()[0].Detail(), "kaleido_platform_kms_key")
 }

--- a/kaleido/platform/kms_folder.go
+++ b/kaleido/platform/kms_folder.go
@@ -196,7 +196,7 @@ func (r *kms_folderResource) Read(ctx context.Context, req resource.ReadRequest,
 }
 
 func (r *kms_folderResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
-	// All mutable fields use RequireRecreate — this method should never be called.
+	// All immutable fields use RequireRecreate — this method should never be called.
 	var data KMSFolderResourceModel
 	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
 	resp.Diagnostics.Append(resp.State.Set(ctx, data)...)

--- a/kaleido/platform/kms_folder.go
+++ b/kaleido/platform/kms_folder.go
@@ -24,6 +24,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/kaleido-io/terraform-provider-kaleido/kaleido/planmodifiers"
 )
 
 type KMSFolderResourceModel struct {
@@ -66,8 +67,9 @@ func (r *kms_folderResource) Metadata(_ context.Context, _ resource.MetadataRequ
 }
 
 func (r *kms_folderResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	const typeName = "kaleido_platform_kms_folder"
 	resp.Schema = schema.Schema{
-		Description: "A folder within a KMS keystore, used to organise keys into a hierarchy. Folders cannot be renamed or moved after creation — changes require replacement. A folder cannot be deleted while it still contains keys or sub-folders.",
+		Description: "A folder within a KMS keystore, used to organise keys into a hierarchy. Folders cannot be renamed or moved after creation — changes are not supported and require destroying and recreating the folder. A folder cannot be deleted while it still contains keys or sub-folders.",
 		Attributes: map[string]schema.Attribute{
 			"id": &schema.StringAttribute{
 				Computed:      true,
@@ -75,28 +77,28 @@ func (r *kms_folderResource) Schema(_ context.Context, _ resource.SchemaRequest,
 			},
 			"environment": &schema.StringAttribute{
 				Required:      true,
-				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
-				Description:   "Environment ID",
+				PlanModifiers: []planmodifier.String{planmodifiers.RequireRecreate(typeName)},
+				Description:   "Environment ID. Immutable after create — changing this value is not supported; destroy and recreate the folder instead.",
 			},
 			"service": &schema.StringAttribute{
 				Required:      true,
-				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
-				Description:   "Key Manager Service ID",
+				PlanModifiers: []planmodifier.String{planmodifiers.RequireRecreate(typeName)},
+				Description:   "Key Manager Service ID. Immutable after create — changing this value is not supported; destroy and recreate the folder instead.",
 			},
 			"keystore": &schema.StringAttribute{
 				Required:      true,
-				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
-				Description:   "Keystore (KMS Wallet) ID",
+				PlanModifiers: []planmodifier.String{planmodifiers.RequireRecreate(typeName)},
+				Description:   "Keystore (KMS Wallet) ID. Immutable after create — changing this value is not supported; destroy and recreate the folder instead.",
 			},
 			"name": &schema.StringAttribute{
 				Required:      true,
-				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
-				Description:   "Folder name",
+				PlanModifiers: []planmodifier.String{planmodifiers.RequireRecreate(typeName)},
+				Description:   "Folder name. Immutable after create — changing this value is not supported; destroy and recreate the folder instead.",
 			},
 			"parent_folder_id": &schema.StringAttribute{
 				Optional:      true,
-				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
-				Description:   "ID of the parent folder. Omit to create a root-level folder.",
+				PlanModifiers: []planmodifier.String{planmodifiers.RequireRecreate(typeName)},
+				Description:   "ID of the parent folder. Omit to create a root-level folder. Immutable after create — changing this value is not supported; destroy and recreate the folder instead.",
 			},
 			"path": &schema.StringAttribute{
 				Computed:    true,
@@ -194,7 +196,7 @@ func (r *kms_folderResource) Read(ctx context.Context, req resource.ReadRequest,
 }
 
 func (r *kms_folderResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
-	// All mutable fields are RequiresReplace — this method should never be called.
+	// All mutable fields use RequireRecreate — this method should never be called.
 	var data KMSFolderResourceModel
 	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
 	resp.Diagnostics.Append(resp.State.Set(ctx, data)...)

--- a/kaleido/platform/kms_folder.go
+++ b/kaleido/platform/kms_folder.go
@@ -78,27 +78,27 @@ func (r *kms_folderResource) Schema(_ context.Context, _ resource.SchemaRequest,
 			"environment": &schema.StringAttribute{
 				Required:      true,
 				PlanModifiers: []planmodifier.String{planmodifiers.RequireRecreate(typeName)},
-				Description:   "Environment ID. Immutable after create — changing this value is not supported; destroy and recreate the folder instead.",
+				Description:   "Environment ID. Immutable after create — changing this value is not supported; create a new, separate folder instead.",
 			},
 			"service": &schema.StringAttribute{
 				Required:      true,
 				PlanModifiers: []planmodifier.String{planmodifiers.RequireRecreate(typeName)},
-				Description:   "Key Manager Service ID. Immutable after create — changing this value is not supported; destroy and recreate the folder instead.",
+				Description:   "Key Manager Service ID. Immutable after create — changing this value is not supported; create a new, separate folder instead.",
 			},
 			"keystore": &schema.StringAttribute{
 				Required:      true,
 				PlanModifiers: []planmodifier.String{planmodifiers.RequireRecreate(typeName)},
-				Description:   "Keystore (KMS Wallet) ID. Immutable after create — changing this value is not supported; destroy and recreate the folder instead.",
+				Description:   "Keystore (KMS Wallet) ID. Immutable after create — changing this value is not supported; create a new, separate folder instead.",
 			},
 			"name": &schema.StringAttribute{
 				Required:      true,
 				PlanModifiers: []planmodifier.String{planmodifiers.RequireRecreate(typeName)},
-				Description:   "Folder name. Immutable after create — changing this value is not supported; destroy and recreate the folder instead.",
+				Description:   "Folder name. Immutable after create — changing this value is not supported; create a new, separate folder instead.",
 			},
 			"parent_folder_id": &schema.StringAttribute{
 				Optional:      true,
 				PlanModifiers: []planmodifier.String{planmodifiers.RequireRecreate(typeName)},
-				Description:   "ID of the parent folder. Omit to create a root-level folder. Immutable after create — changing this value is not supported; destroy and recreate the folder instead.",
+				Description:   "ID of the parent folder. Omit to create a root-level folder. Immutable after create — changing this value is not supported; create a new, separate folder instead.",
 			},
 			"path": &schema.StringAttribute{
 				Computed:    true,

--- a/kaleido/platform/kms_key.go
+++ b/kaleido/platform/kms_key.go
@@ -97,9 +97,10 @@ func (r *kms_keyResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 				Description: "Key Display Name",
 			},
 			"path": &schema.StringAttribute{
-				Optional:    true,
-				Computed:    true,
-				Description: "A unique identifier for a piece of key material that is understood by the associated signing technology for a wallet. Each key that exists must have a path to associate the key with the key material that is used for signing.",
+				Optional:      true,
+				Computed:      true,
+				PlanModifiers: []planmodifier.String{planmodifiers.RequireRecreate(typeName)},
+				Description:   "A unique identifier for a piece of key material that is understood by the associated signing technology for a wallet. Each key that exists must have a path to associate the key with the key material that is used for signing.",
 			},
 			"folder_path": &schema.StringAttribute{
 				Optional:      true,
@@ -115,9 +116,10 @@ func (r *kms_keyResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 				Computed: true,
 			},
 			"attributes": &schema.MapAttribute{
-				Optional:    true,
-				ElementType: types.StringType,
-				Description: "Optional attributes of the key for key creation.",
+				Optional:      true,
+				ElementType:   types.StringType,
+				PlanModifiers: []planmodifier.Map{planmodifiers.RequireRecreateMap(typeName)},
+				Description:   "Optional attributes of the key for key creation.",
 			},
 			"public_identifier_types": &schema.ListAttribute{
 				Optional:    true,

--- a/kaleido/platform/kms_key.go
+++ b/kaleido/platform/kms_key.go
@@ -187,6 +187,17 @@ func (r *kms_keyResource) apiPath(ctx context.Context, data *KMSKeyResourceModel
 	return p, wallet.Name, true
 }
 
+func (data *KMSKeyResourceModel) hasFolderPath() bool {
+	return !data.FolderPath.IsNull() && data.FolderPath.ValueString() != ""
+}
+
+// keyByIDPath is the global KMS key-by-ID route. Unlike the wallet-scoped path, it
+// finds keys inside folders, so DELETE + waitForRemoval can rely on a real 404.
+func (r *kms_keyResource) keyByIDPath(data *KMSKeyResourceModel) string {
+	return fmt.Sprintf("/endpoint/%s/%s/rest/api/v1/keys/%s",
+		data.Environment.ValueString(), data.Service.ValueString(), data.ID.ValueString())
+}
+
 func (r *kms_keyResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 
 	var data KMSKeyResourceModel
@@ -201,7 +212,7 @@ func (r *kms_keyResource) Create(ctx context.Context, req resource.CreateRequest
 	if ok {
 		// If the user specified a folder_path, build the URI so the API auto-creates
 		// the folder hierarchy and places the key within it.
-		if !data.FolderPath.IsNull() && data.FolderPath.ValueString() != "" {
+		if data.hasFolderPath() {
 			path := strings.TrimPrefix(data.FolderPath.ValueString(), "/")
 			api.URI = fmt.Sprintf("kld:///keystore/%s/key/%s/%s", walletName, path, data.Name.ValueString())
 		}
@@ -272,9 +283,10 @@ func (r *kms_keyResource) Read(ctx context.Context, req resource.ReadRequest, re
 		return
 	}
 	if status == 404 {
-		// The v1 GET-by-ID does not traverse folder hierarchy; a folder-placed key
-		// will 404 here even though it exists. Preserve state so subsequent plans
-		// remain stable. Plain (non-folder) keys are correctly removed on 404.
+		// The v1 wallet-scoped GET-by-ID does not traverse folder hierarchy; a
+		// folder-placed key will 404 here even though it exists. Preserve state so
+		// subsequent plans remain stable. Plain (non-folder) keys are correctly
+		// removed on 404.
 		if !currentFolderPath.IsNull() && currentFolderPath.ValueString() != "" {
 			resp.Diagnostics.Append(resp.State.Set(ctx, data)...)
 			return
@@ -297,11 +309,22 @@ func (r *kms_keyResource) Delete(ctx context.Context, req resource.DeleteRequest
 	var data KMSKeyResourceModel
 	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
 
-	apiPath, _, ok := r.apiPath(ctx, &data, &resp.Diagnostics)
-	if !ok {
+	// Folder keys are not included in the wallet-scoped GET path (always 404 even
+	// when present). Delete and confirm removal via the global by-ID endpoint
+	var deletePath string
+	if data.hasFolderPath() {
+		deletePath = r.keyByIDPath(&data)
+	} else {
+		var ok bool
+		deletePath, _, ok = r.apiPath(ctx, &data, &resp.Diagnostics)
+		if !ok {
+			return
+		}
+	}
+
+	if ok, _ := r.apiRequest(ctx, http.MethodDelete, deletePath, nil, nil, &resp.Diagnostics, Allow404()); !ok {
 		return
 	}
-	_, _ = r.apiRequest(ctx, http.MethodDelete, apiPath, nil, nil, &resp.Diagnostics, Allow404())
 
-	r.waitForRemoval(ctx, apiPath, &resp.Diagnostics)
+	r.waitForRemoval(ctx, deletePath, &resp.Diagnostics)
 }

--- a/kaleido/platform/kms_key.go
+++ b/kaleido/platform/kms_key.go
@@ -80,17 +80,17 @@ func (r *kms_keyResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 			"environment": &schema.StringAttribute{
 				Required:      true,
 				PlanModifiers: []planmodifier.String{planmodifiers.RequireRecreate(typeName)},
-				Description:   "Environment ID. Immutable after create — changing this value is not supported; destroy and recreate the key instead.",
+				Description:   "Environment ID. Immutable after create — changing this value is not supported; create a new, separate key instead.",
 			},
 			"service": &schema.StringAttribute{
 				Required:      true,
 				PlanModifiers: []planmodifier.String{planmodifiers.RequireRecreate(typeName)},
-				Description:   "Key Manager Service ID. Immutable after create — changing this value is not supported; destroy and recreate the key instead.",
+				Description:   "Key Manager Service ID. Immutable after create — changing this value is not supported; create a new, separate key instead.",
 			},
 			"wallet": &schema.StringAttribute{
 				Required:      true,
 				PlanModifiers: []planmodifier.String{planmodifiers.RequireRecreate(typeName)},
-				Description:   "Wallet ID. Immutable after create — changing this value is not supported; destroy and recreate the key instead.",
+				Description:   "Wallet ID. Immutable after create — changing this value is not supported; create a new, separate key instead.",
 			},
 			"name": &schema.StringAttribute{
 				Required:    true, // technically optional in Kaleido service, but it is an anti-pattern we do not support in the terraform provider
@@ -104,7 +104,7 @@ func (r *kms_keyResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 			"folder_path": &schema.StringAttribute{
 				Optional:      true,
 				PlanModifiers: []planmodifier.String{planmodifiers.RequireRecreate(typeName)},
-				Description:   "Slash-separated folder hierarchy to place this key in, e.g. \"treasury\" or \"ops/hot\". Folders are automatically created if they do not exist. Immutable after create — changing this value is not supported; destroy and recreate the key instead.",
+				Description:   "Slash-separated folder hierarchy to place this key in, e.g. \"treasury\" or \"ops/hot\". Folders are automatically created if they do not exist. Immutable after create — changing this value is not supported; create a new, separate key instead.",
 			},
 			"uri": &schema.StringAttribute{
 				Computed:      true,

--- a/kaleido/platform/kms_key.go
+++ b/kaleido/platform/kms_key.go
@@ -96,6 +96,14 @@ func (r *kms_keyResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 				Required:    true, // technically optional in Kaleido service, but it is an anti-pattern we do not support in the terraform provider
 				Description: "Key Display Name",
 			},
+			"uri": &schema.StringAttribute{
+				Computed:    true,
+				Description: "The canonical URI of the key, assigned by the server after creation. Updates when the key is renamed.",
+			},
+			"address": &schema.StringAttribute{
+				Computed:      true,
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+			},
 			"path": &schema.StringAttribute{
 				Optional:      true,
 				Computed:      true,
@@ -107,14 +115,6 @@ func (r *kms_keyResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 				PlanModifiers: []planmodifier.String{planmodifiers.RequireRecreate(typeName)},
 				Description:   "Slash-separated folder hierarchy to place this key in, e.g. \"treasury\" or \"ops/hot\". Folders are automatically created if they do not exist. Immutable after create — changing this value is not supported; create a new, separate key instead.",
 			},
-			"uri": &schema.StringAttribute{
-				Computed:      true,
-				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
-				Description:   "The canonical URI of the key, assigned by the server after creation.",
-			},
-			"address": &schema.StringAttribute{
-				Computed: true,
-			},
 			"attributes": &schema.MapAttribute{
 				Optional:      true,
 				ElementType:   types.StringType,
@@ -122,9 +122,10 @@ func (r *kms_keyResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 				Description:   "Optional attributes of the key for key creation. Immutable after create — changing this value is not supported; create a new, separate key instead.",
 			},
 			"public_identifier_types": &schema.ListAttribute{
-				Optional:    true,
-				ElementType: types.StringType,
-				Description: "Optional public identifier types to create for the key.",
+				Optional:      true,
+				ElementType:   types.StringType,
+				PlanModifiers: []planmodifier.List{planmodifiers.RequireRecreateList(typeName)},
+				Description:   "Optional public identifier types to create for the key. Applied only at create — immutable after create; changing this value is not supported; create a new, separate key instead.",
 			},
 		},
 	}
@@ -194,10 +195,20 @@ func (data *KMSKeyResourceModel) hasFolderPath() bool {
 }
 
 // keyByIDPath is the global KMS key-by-ID route. Unlike the wallet-scoped path, it
-// finds keys inside folders, so DELETE + waitForRemoval can rely on a real 404.
+// finds keys inside folders, so GET/PATCH/DELETE can rely on it for folder-placed keys.
 func (r *kms_keyResource) keyByIDPath(data *KMSKeyResourceModel) string {
 	return fmt.Sprintf("/endpoint/%s/%s/rest/api/v1/keys/%s",
 		data.Environment.ValueString(), data.Service.ValueString(), data.ID.ValueString())
+}
+
+// keyMutationPath returns the path for GET/PATCH/DELETE of an existing key.
+// Folder keys must use the global by-ID route
+func (r *kms_keyResource) keyMutationPath(ctx context.Context, data *KMSKeyResourceModel, diagnostics *diag.Diagnostics) (string, bool) {
+	if data.hasFolderPath() {
+		return r.keyByIDPath(data), true
+	}
+	p, _, ok := r.apiPath(ctx, data, diagnostics)
+	return p, ok
 }
 
 func (r *kms_keyResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
@@ -242,19 +253,23 @@ func (r *kms_keyResource) Update(ctx context.Context, req resource.UpdateRequest
 	// Preserve planned publicIdentifierTypes, as API does not return them on GET
 	plannedPublicIdentifierTypes := data.PublicIdentifierTypes
 
-	// Read full current object
-	var api KMSKeyAPIModel
-	apiPath, _, ok := r.apiPath(ctx, &data, &resp.Diagnostics)
-	if ok {
-		ok, _ = r.apiRequest(ctx, http.MethodGet, apiPath, nil, &api, &resp.Diagnostics)
-	}
+	keyPath, ok := r.keyMutationPath(ctx, &data, &resp.Diagnostics)
 	if !ok {
 		return
 	}
 
-	// Update from plan (immutable fields use RequireRecreate so cannot change here)
-	data.toAPI(ctx, &api, &resp.Diagnostics)
-	if ok, _ = r.apiRequest(ctx, http.MethodPatch /* note there is no put-by-ID */, apiPath, api, &api, &resp.Diagnostics); !ok {
+	// Read full current object
+	var api KMSKeyAPIModel
+	if ok, _ = r.apiRequest(ctx, http.MethodGet, keyPath, nil, &api, &resp.Diagnostics); !ok {
+		return
+	}
+
+	// Update from plan. Key PATCH only accepts name - URI will be updated based on the new name
+	patch := KMSKeyAPIModel{
+		ID:   api.ID,
+		Name: data.Name.ValueString(),
+	}
+	if ok, _ = r.apiRequest(ctx, http.MethodPatch /* note there is no put-by-ID */, keyPath, patch, &api, &resp.Diagnostics); !ok {
 		return
 	}
 
@@ -313,15 +328,9 @@ func (r *kms_keyResource) Delete(ctx context.Context, req resource.DeleteRequest
 
 	// Folder keys are not included in the wallet-scoped GET path (always 404 even
 	// when present). Delete and confirm removal via the global by-ID endpoint
-	var deletePath string
-	if data.hasFolderPath() {
-		deletePath = r.keyByIDPath(&data)
-	} else {
-		var ok bool
-		deletePath, _, ok = r.apiPath(ctx, &data, &resp.Diagnostics)
-		if !ok {
-			return
-		}
+	deletePath, ok := r.keyMutationPath(ctx, &data, &resp.Diagnostics)
+	if !ok {
+		return
 	}
 
 	if ok, _ := r.apiRequest(ctx, http.MethodDelete, deletePath, nil, nil, &resp.Diagnostics, Allow404()); !ok {

--- a/kaleido/platform/kms_key.go
+++ b/kaleido/platform/kms_key.go
@@ -27,6 +27,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/kaleido-io/terraform-provider-kaleido/kaleido/planmodifiers"
 )
 
 type KMSKeyResourceModel struct {
@@ -68,6 +69,7 @@ func (r *kms_keyResource) Metadata(_ context.Context, _ resource.MetadataRequest
 }
 
 func (r *kms_keyResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	const typeName = "kaleido_platform_kms_key"
 	resp.Schema = schema.Schema{
 		Description: "A reference to a signing key (also known as a key mapping) that is directly/indirectly derived from a piece of key material, and can be used for signing.",
 		Attributes: map[string]schema.Attribute{
@@ -77,18 +79,18 @@ func (r *kms_keyResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 			},
 			"environment": &schema.StringAttribute{
 				Required:      true,
-				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
-				Description:   "Environment ID",
+				PlanModifiers: []planmodifier.String{planmodifiers.RequireRecreate(typeName)},
+				Description:   "Environment ID. Immutable after create — changing this value is not supported; destroy and recreate the key instead.",
 			},
 			"service": &schema.StringAttribute{
 				Required:      true,
-				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
-				Description:   "Key Manager Service ID",
+				PlanModifiers: []planmodifier.String{planmodifiers.RequireRecreate(typeName)},
+				Description:   "Key Manager Service ID. Immutable after create — changing this value is not supported; destroy and recreate the key instead.",
 			},
 			"wallet": &schema.StringAttribute{
 				Required:      true,
-				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
-				Description:   "Wallet ID",
+				PlanModifiers: []planmodifier.String{planmodifiers.RequireRecreate(typeName)},
+				Description:   "Wallet ID. Immutable after create — changing this value is not supported; destroy and recreate the key instead.",
 			},
 			"name": &schema.StringAttribute{
 				Required:    true, // technically optional in Kaleido service, but it is an anti-pattern we do not support in the terraform provider
@@ -101,8 +103,8 @@ func (r *kms_keyResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 			},
 			"folder_path": &schema.StringAttribute{
 				Optional:      true,
-				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
-				Description:   "Slash-separated folder hierarchy to place this key in, e.g. \"treasury\" or \"ops/hot\". Folders are automatically created if they do not exist. Changing this field requires key replacement.",
+				PlanModifiers: []planmodifier.String{planmodifiers.RequireRecreate(typeName)},
+				Description:   "Slash-separated folder hierarchy to place this key in, e.g. \"treasury\" or \"ops/hot\". Folders are automatically created if they do not exist. Immutable after create — changing this value is not supported; destroy and recreate the key instead.",
 			},
 			"uri": &schema.StringAttribute{
 				Computed:      true,
@@ -237,7 +239,7 @@ func (r *kms_keyResource) Update(ctx context.Context, req resource.UpdateRequest
 		return
 	}
 
-	// Update from plan (folder_path is RequiresReplace so never changes here)
+	// Update from plan (immutable fields use RequireRecreate so cannot change here)
 	data.toAPI(ctx, &api, &resp.Diagnostics)
 	if ok, _ = r.apiRequest(ctx, http.MethodPatch /* note there is no put-by-ID */, apiPath, api, &api, &resp.Diagnostics); !ok {
 		return

--- a/kaleido/platform/kms_key.go
+++ b/kaleido/platform/kms_key.go
@@ -100,7 +100,7 @@ func (r *kms_keyResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 				Optional:      true,
 				Computed:      true,
 				PlanModifiers: []planmodifier.String{planmodifiers.RequireRecreate(typeName)},
-				Description:   "A unique identifier for a piece of key material that is understood by the associated signing technology for a wallet. Each key that exists must have a path to associate the key with the key material that is used for signing.",
+				Description:   "A unique identifier for a piece of key material that is understood by the associated signing technology for a wallet. Each key that exists must have a path to associate the key with the key material that is used for signing. Immutable after create — changing this value is not supported; create a new, separate key instead.",
 			},
 			"folder_path": &schema.StringAttribute{
 				Optional:      true,
@@ -119,7 +119,7 @@ func (r *kms_keyResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 				Optional:      true,
 				ElementType:   types.StringType,
 				PlanModifiers: []planmodifier.Map{planmodifiers.RequireRecreateMap(typeName)},
-				Description:   "Optional attributes of the key for key creation.",
+				Description:   "Optional attributes of the key for key creation. Immutable after create — changing this value is not supported; create a new, separate key instead.",
 			},
 			"public_identifier_types": &schema.ListAttribute{
 				Optional:    true,

--- a/kaleido/platform/kms_key.go
+++ b/kaleido/platform/kms_key.go
@@ -107,7 +107,7 @@ func (r *kms_keyResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 			"path": &schema.StringAttribute{
 				Optional:      true,
 				Computed:      true,
-				PlanModifiers: []planmodifier.String{planmodifiers.RequireRecreate(typeName)},
+				PlanModifiers: []planmodifier.String{planmodifiers.RequireRecreate(typeName), stringplanmodifier.UseStateForUnknown()},
 				Description:   "A unique identifier for a piece of key material that is understood by the associated signing technology for a wallet. Each key that exists must have a path to associate the key with the key material that is used for signing. Immutable after create — changing this value is not supported; create a new, separate key instead.",
 			},
 			"folder_path": &schema.StringAttribute{

--- a/kaleido/platform/kms_key_test.go
+++ b/kaleido/platform/kms_key_test.go
@@ -76,6 +76,21 @@ resource "kaleido_platform_kms_key" "kms_key1" {
 }
 `
 
+var kms_keyStepImmutablePublicIdentifiers = `
+resource "kaleido_platform_kms_key" "kms_key1" {
+    environment = "env1"
+	service = "service1"
+	wallet = "wallet1_id"
+    name = "kms_key1_renamed"
+	path = "some/path"
+	attributes = {
+		"attribute1" = "value1"
+		"attribute2" = "value2"
+	}
+	public_identifier_types = ["address_ethereum", "address_ethereum_checksum"]
+}
+`
+
 func TestKMSKey1(t *testing.T) {
 
 	mp, providerConfig := testSetup(t)
@@ -92,6 +107,9 @@ func TestKMSKey1(t *testing.T) {
 			"PATCH /endpoint/{env}/{service}/rest/api/v1/wallets/{wallet}/keys/{key}",
 			"GET /endpoint/{env}/{service}/rest/api/v1/wallets/{wallet}",
 			"GET /endpoint/{env}/{service}/rest/api/v1/wallets/{wallet}/keys/{key}",
+			"GET /endpoint/{env}/{service}/rest/api/v1/wallets/{wallet}",
+			"GET /endpoint/{env}/{service}/rest/api/v1/wallets/{wallet}/keys/{key}",
+			// ExpectError steps refresh then fail during plan (immutable attrs)
 			"GET /endpoint/{env}/{service}/rest/api/v1/wallets/{wallet}",
 			"GET /endpoint/{env}/{service}/rest/api/v1/wallets/{wallet}/keys/{key}",
 			"GET /endpoint/{env}/{service}/rest/api/v1/wallets/{wallet}",
@@ -149,8 +167,7 @@ func TestKMSKey1(t *testing.T) {
 							"attributes": {
 								"attribute1": "value1",
 								"attribute2": "value2"
-							},
-							"publicIdentifierTypes": ["address_ethereum"]
+							}
 						}
 						`,
 							// generated fields that vary per test run
@@ -165,6 +182,10 @@ func TestKMSKey1(t *testing.T) {
 			},
 			{
 				Config:      providerConfig + kms_keyStepImmutablePath,
+				ExpectError: regexp.MustCompile(`Immutable attribute cannot be updated`),
+			},
+			{
+				Config:      providerConfig + kms_keyStepImmutablePublicIdentifiers,
 				ExpectError: regexp.MustCompile(`Immutable attribute cannot be updated`),
 			},
 		},
@@ -215,13 +236,55 @@ func (mp *mockPlatform) patchKMSKey(res http.ResponseWriter, req *http.Request) 
 	mp.getBody(req, &newObj)
 	assert.Equal(mp.t, obj.ID, newObj.ID)            // expected behavior of provider
 	assert.Equal(mp.t, obj.ID, mux.Vars(req)["key"]) // expected behavior of provider
+	assert.Empty(mp.t, newObj.URI, "PATCH must not echo URI; KM rejects name/URI mismatch (KA053006)")
 	now := time.Now().UTC()
 	newObj.Created = obj.Created
 	newObj.Updated = &now
 	newObj.Address = obj.Address
-	newObj.URI = obj.URI // canonical URI is immutable after create
+	newObj.URI = obj.URI // server regenerates; mock keeps prior URI for simplicity
+	if newObj.Path == "" {
+		newObj.Path = obj.Path
+	}
+	if newObj.Attributes == nil {
+		newObj.Attributes = obj.Attributes
+	}
+	if newObj.PublicIdentifierTypes == nil {
+		newObj.PublicIdentifierTypes = obj.PublicIdentifierTypes
+	}
 	mp.kmsKeys[mux.Vars(req)["env"]+"/"+mux.Vars(req)["service"]+"/"+mux.Vars(req)["wallet"]+"/"+mux.Vars(req)["key"]] = &newObj
 	mp.kmsKeysByID[mux.Vars(req)["env"]+"/"+mux.Vars(req)["service"]+"/"+mux.Vars(req)["key"]] = &newObj
+	mp.respond(res, &newObj, 200)
+}
+
+func (mp *mockPlatform) patchKMSKeyByID(res http.ResponseWriter, req *http.Request) {
+	idKey := mux.Vars(req)["env"] + "/" + mux.Vars(req)["service"] + "/" + mux.Vars(req)["key"]
+	obj := mp.kmsKeysByID[idKey]
+	assert.NotNil(mp.t, obj)
+	var newObj KMSKeyAPIModel
+	mp.getBody(req, &newObj)
+	assert.Equal(mp.t, obj.ID, newObj.ID)
+	assert.Equal(mp.t, obj.ID, mux.Vars(req)["key"])
+	assert.Empty(mp.t, newObj.URI, "PATCH must not echo URI; KM rejects name/URI mismatch (KA053006)")
+	now := time.Now().UTC()
+	newObj.Created = obj.Created
+	newObj.Updated = &now
+	newObj.Address = obj.Address
+	newObj.URI = obj.URI
+	if newObj.Path == "" {
+		newObj.Path = obj.Path
+	}
+	if newObj.Attributes == nil {
+		newObj.Attributes = obj.Attributes
+	}
+	if newObj.PublicIdentifierTypes == nil {
+		newObj.PublicIdentifierTypes = obj.PublicIdentifierTypes
+	}
+	mp.kmsKeysByID[idKey] = &newObj
+	for k, v := range mp.kmsKeys {
+		if v.ID == obj.ID {
+			mp.kmsKeys[k] = &newObj
+		}
+	}
 	mp.respond(res, &newObj, 200)
 }
 
@@ -252,19 +315,39 @@ resource "kaleido_platform_kms_key" "kms_key_folder" {
 	service = "service1"
 	wallet = "wallet1_id"
     name = "folder_key"
-	folder_path = "keys/hot"
+	folder_path = "keys/folder"
 	public_identifier_types = ["address_ethereum"]
 }
 `
 
-func TestKMSKeyFolderDelete(t *testing.T) {
+var kms_keyFolderStepRename = `
+resource "kaleido_platform_kms_key" "kms_key_folder" {
+    environment = "env1"
+	service = "service1"
+	wallet = "wallet1_id"
+    name = "folder_key_renamed"
+	folder_path = "keys/folder"
+	public_identifier_types = ["address_ethereum"]
+}
+`
+
+func TestKMSKeyFolderUpdateAndDelete(t *testing.T) {
 	mp, providerConfig := testSetup(t)
 	defer func() {
 		mp.checkClearCalls([]string{
 			// Create
 			"GET /endpoint/{env}/{service}/rest/api/v1/wallets/{wallet}",
 			"PUT /endpoint/{env}/{service}/rest/api/v1/wallets/{wallet}/keys",
-			// Read refresh (wallet-scoped)
+			// Read refresh after create (wallet-scoped — 404 preserved for folder keys)
+			"GET /endpoint/{env}/{service}/rest/api/v1/wallets/{wallet}",
+			"GET /endpoint/{env}/{service}/rest/api/v1/wallets/{wallet}/keys/{key}",
+			// Plan refresh before update
+			"GET /endpoint/{env}/{service}/rest/api/v1/wallets/{wallet}",
+			"GET /endpoint/{env}/{service}/rest/api/v1/wallets/{wallet}/keys/{key}",
+			// Update via global by-ID path
+			"GET /endpoint/{env}/{service}/rest/api/v1/keys/{key}",
+			"PATCH /endpoint/{env}/{service}/rest/api/v1/keys/{key}",
+			// Read refresh after update
 			"GET /endpoint/{env}/{service}/rest/api/v1/wallets/{wallet}",
 			"GET /endpoint/{env}/{service}/rest/api/v1/wallets/{wallet}/keys/{key}",
 			// Delete via global by-ID path + waitForRemoval on same path
@@ -285,8 +368,23 @@ func TestKMSKeyFolderDelete(t *testing.T) {
 				Config: providerConfig + kms_keyFolderStep,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet(resourceName, "id"),
-					resource.TestCheckResourceAttr(resourceName, "folder_path", "keys/hot"),
+					resource.TestCheckResourceAttr(resourceName, "folder_path", "keys/folder"),
 					resource.TestCheckResourceAttr(resourceName, "name", "folder_key"),
+				),
+			},
+			{
+				Config: providerConfig + kms_keyFolderStepRename,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "folder_path", "keys/folder"),
+					resource.TestCheckResourceAttr(resourceName, "name", "folder_key_renamed"),
+					func(s *terraform.State) error {
+						id := s.RootModule().Resources[resourceName].Primary.Attributes["id"]
+						obj := mp.kmsKeysByID[fmt.Sprintf("env1/service1/%s", id)]
+						assert.NotNil(t, obj)
+						assert.Equal(t, "folder_key_renamed", obj.Name)
+						return nil
+					},
 				),
 			},
 		},

--- a/kaleido/platform/kms_key_test.go
+++ b/kaleido/platform/kms_key_test.go
@@ -16,6 +16,7 @@ package platform
 import (
 	"fmt"
 	"net/http"
+	"regexp"
 	"testing"
 	"time"
 
@@ -34,20 +35,39 @@ resource "kaleido_platform_kms_key" "kms_key1" {
 	service = "service1"
 	wallet = "wallet1_id"
     name = "kms_key1"
+	path = "some/path"
 	attributes = {
 		"attribute1" = "value1"
+		"attribute2" = "value2"
 	}
 	public_identifier_types = ["address_ethereum"]
 }
 `
 
+// Mutable update only — path/attributes are immutable (RequireRecreate).
 var kms_keyStep2 = `
 resource "kaleido_platform_kms_key" "kms_key1" {
     environment = "env1"
 	service = "service1"
 	wallet = "wallet1_id"
-    name = "kms_key1"
+    name = "kms_key1_renamed"
 	path = "some/path"
+	attributes = {
+		"attribute1" = "value1"
+		"attribute2" = "value2"
+	}
+	public_identifier_types = ["address_ethereum"]
+}
+`
+
+// Changing an immutable field must fail planning (no automatic replace).
+var kms_keyStepImmutablePath = `
+resource "kaleido_platform_kms_key" "kms_key1" {
+    environment = "env1"
+	service = "service1"
+	wallet = "wallet1_id"
+    name = "kms_key1_renamed"
+	path = "other/path"
 	attributes = {
 		"attribute1" = "value1"
 		"attribute2" = "value2"
@@ -73,6 +93,8 @@ func TestKMSKey1(t *testing.T) {
 			"GET /endpoint/{env}/{service}/rest/api/v1/wallets/{wallet}",
 			"GET /endpoint/{env}/{service}/rest/api/v1/wallets/{wallet}/keys/{key}",
 			"GET /endpoint/{env}/{service}/rest/api/v1/wallets/{wallet}",
+			"GET /endpoint/{env}/{service}/rest/api/v1/wallets/{wallet}/keys/{key}",
+			"GET /endpoint/{env}/{service}/rest/api/v1/wallets/{wallet}",
 			"DELETE /endpoint/{env}/{service}/rest/api/v1/wallets/{wallet}/keys/{key}",
 			"GET /endpoint/{env}/{service}/rest/api/v1/wallets/{wallet}/keys/{key}",
 		})
@@ -92,9 +114,11 @@ func TestKMSKey1(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet(kms_key1Resource, "id"),
 					resource.TestCheckResourceAttr(kms_key1Resource, "name", `kms_key1`),
+					resource.TestCheckResourceAttr(kms_key1Resource, "path", `some/path`),
 					resource.TestCheckResourceAttr(kms_key1Resource, "uri", `uri/for/kms_key1`),
 					resource.TestCheckResourceAttrSet(kms_key1Resource, "address"),
 					resource.TestCheckResourceAttr(kms_key1Resource, "attributes.attribute1", `value1`),
+					resource.TestCheckResourceAttr(kms_key1Resource, "attributes.attribute2", `value2`),
 					resource.TestCheckResourceAttr(kms_key1Resource, "public_identifier_types.0", `address_ethereum`),
 				),
 			},
@@ -102,7 +126,7 @@ func TestKMSKey1(t *testing.T) {
 				Config: providerConfig + kms_keyStep2,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet(kms_key1Resource, "id"),
-					resource.TestCheckResourceAttr(kms_key1Resource, "name", `kms_key1`),
+					resource.TestCheckResourceAttr(kms_key1Resource, "name", `kms_key1_renamed`),
 					resource.TestCheckResourceAttr(kms_key1Resource, "path", `some/path`),
 					resource.TestCheckResourceAttr(kms_key1Resource, "uri", `uri/for/kms_key1`),
 					resource.TestCheckResourceAttrSet(kms_key1Resource, "address"),
@@ -118,7 +142,7 @@ func TestKMSKey1(t *testing.T) {
 							"id": "%[1]s",
 							"created": "%[2]s",
 							"updated": "%[3]s",
-							"name": "kms_key1",
+							"name": "kms_key1_renamed",
 							"path": "some/path",
 							"address": "%[4]s",
 							"uri": "uri/for/kms_key1",
@@ -138,6 +162,10 @@ func TestKMSKey1(t *testing.T) {
 						return nil
 					},
 				),
+			},
+			{
+				Config:      providerConfig + kms_keyStepImmutablePath,
+				ExpectError: regexp.MustCompile(`Immutable attribute cannot be updated`),
 			},
 		},
 	})
@@ -190,7 +218,8 @@ func (mp *mockPlatform) patchKMSKey(res http.ResponseWriter, req *http.Request) 
 	now := time.Now().UTC()
 	newObj.Created = obj.Created
 	newObj.Updated = &now
-	newObj.URI = "uri/for/" + newObj.Name
+	newObj.Address = obj.Address
+	newObj.URI = obj.URI // canonical URI is immutable after create
 	mp.kmsKeys[mux.Vars(req)["env"]+"/"+mux.Vars(req)["service"]+"/"+mux.Vars(req)["wallet"]+"/"+mux.Vars(req)["key"]] = &newObj
 	mp.kmsKeysByID[mux.Vars(req)["env"]+"/"+mux.Vars(req)["service"]+"/"+mux.Vars(req)["key"]] = &newObj
 	mp.respond(res, &newObj, 200)

--- a/kaleido/platform/kms_key_test.go
+++ b/kaleido/platform/kms_key_test.go
@@ -152,6 +152,15 @@ func (mp *mockPlatform) getKMSKey(res http.ResponseWriter, req *http.Request) {
 	}
 }
 
+func (mp *mockPlatform) getKMSKeyByID(res http.ResponseWriter, req *http.Request) {
+	obj := mp.kmsKeysByID[mux.Vars(req)["env"]+"/"+mux.Vars(req)["service"]+"/"+mux.Vars(req)["key"]]
+	if obj == nil {
+		mp.respond(res, nil, 404)
+	} else {
+		mp.respond(res, obj, 200)
+	}
+}
+
 func (mp *mockPlatform) putKMSKey(res http.ResponseWriter, req *http.Request) {
 	var obj KMSKeyAPIModel
 	mp.getBody(req, &obj)
@@ -160,9 +169,14 @@ func (mp *mockPlatform) putKMSKey(res http.ResponseWriter, req *http.Request) {
 	obj.Created = &now
 	obj.Updated = &now
 	obj.Address = nanoid.New()
-	obj.URI = "uri/for/" + obj.Name
+	if obj.URI == "" {
+		obj.URI = "uri/for/" + obj.Name
+	}
 	obj.PublicIdentifierTypes = nil
-	mp.kmsKeys[mux.Vars(req)["env"]+"/"+mux.Vars(req)["service"]+"/"+mux.Vars(req)["wallet"]+"/"+obj.ID] = &obj
+	walletKey := mux.Vars(req)["env"] + "/" + mux.Vars(req)["service"] + "/" + mux.Vars(req)["wallet"] + "/" + obj.ID
+	idKey := mux.Vars(req)["env"] + "/" + mux.Vars(req)["service"] + "/" + obj.ID
+	mp.kmsKeys[walletKey] = &obj
+	mp.kmsKeysByID[idKey] = &obj
 	mp.respond(res, &obj, 201)
 }
 
@@ -178,6 +192,7 @@ func (mp *mockPlatform) patchKMSKey(res http.ResponseWriter, req *http.Request) 
 	newObj.Updated = &now
 	newObj.URI = "uri/for/" + newObj.Name
 	mp.kmsKeys[mux.Vars(req)["env"]+"/"+mux.Vars(req)["service"]+"/"+mux.Vars(req)["wallet"]+"/"+mux.Vars(req)["key"]] = &newObj
+	mp.kmsKeysByID[mux.Vars(req)["env"]+"/"+mux.Vars(req)["service"]+"/"+mux.Vars(req)["key"]] = &newObj
 	mp.respond(res, &newObj, 200)
 }
 
@@ -185,5 +200,68 @@ func (mp *mockPlatform) deleteKMSKey(res http.ResponseWriter, req *http.Request)
 	obj := mp.kmsKeys[mux.Vars(req)["env"]+"/"+mux.Vars(req)["service"]+"/"+mux.Vars(req)["wallet"]+"/"+mux.Vars(req)["key"]]
 	assert.NotNil(mp.t, obj)
 	delete(mp.kmsKeys, mux.Vars(req)["env"]+"/"+mux.Vars(req)["service"]+"/"+mux.Vars(req)["wallet"]+"/"+mux.Vars(req)["key"])
+	delete(mp.kmsKeysByID, mux.Vars(req)["env"]+"/"+mux.Vars(req)["service"]+"/"+mux.Vars(req)["key"])
 	mp.respond(res, nil, 204)
+}
+
+func (mp *mockPlatform) deleteKMSKeyByID(res http.ResponseWriter, req *http.Request) {
+	idKey := mux.Vars(req)["env"] + "/" + mux.Vars(req)["service"] + "/" + mux.Vars(req)["key"]
+	obj := mp.kmsKeysByID[idKey]
+	assert.NotNil(mp.t, obj)
+	delete(mp.kmsKeysByID, idKey)
+	for k, v := range mp.kmsKeys {
+		if v.ID == obj.ID {
+			delete(mp.kmsKeys, k)
+		}
+	}
+	mp.respond(res, nil, 204)
+}
+
+var kms_keyFolderStep = `
+resource "kaleido_platform_kms_key" "kms_key_folder" {
+    environment = "env1"
+	service = "service1"
+	wallet = "wallet1_id"
+    name = "folder_key"
+	folder_path = "keys/hot"
+	public_identifier_types = ["address_ethereum"]
+}
+`
+
+func TestKMSKeyFolderDelete(t *testing.T) {
+	mp, providerConfig := testSetup(t)
+	defer func() {
+		mp.checkClearCalls([]string{
+			// Create
+			"GET /endpoint/{env}/{service}/rest/api/v1/wallets/{wallet}",
+			"PUT /endpoint/{env}/{service}/rest/api/v1/wallets/{wallet}/keys",
+			// Read refresh (wallet-scoped)
+			"GET /endpoint/{env}/{service}/rest/api/v1/wallets/{wallet}",
+			"GET /endpoint/{env}/{service}/rest/api/v1/wallets/{wallet}/keys/{key}",
+			// Delete via global by-ID path + waitForRemoval on same path
+			"DELETE /endpoint/{env}/{service}/rest/api/v1/keys/{key}",
+			"GET /endpoint/{env}/{service}/rest/api/v1/keys/{key}",
+		})
+		mp.server.Close()
+	}()
+
+	mp.kmsWallets["env1/service1/wallet1_id"] = &KMSWalletAPIModel{Name: "wallet1"}
+
+	resourceName := "kaleido_platform_kms_key.kms_key_folder"
+	resource.Test(t, resource.TestCase{
+		IsUnitTest:               true,
+		ProtoV6ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: providerConfig + kms_keyFolderStep,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "folder_path", "keys/hot"),
+					resource.TestCheckResourceAttr(resourceName, "name", "folder_key"),
+				),
+			},
+		},
+	})
+
+	assert.Empty(t, mp.kmsKeysByID, "folder key should be deleted via global /keys/{id} path")
 }

--- a/kaleido/platform/mockserver_test.go
+++ b/kaleido/platform/mockserver_test.go
@@ -191,6 +191,7 @@ func startMockPlatformServer(t *testing.T) *mockPlatform {
 	mp.register("/endpoint/{env}/{service}/rest/api/v1/wallets/{wallet}/keys/{key}", http.MethodDelete, mp.deleteKMSKey)
 	// Global by-ID routes used for folder-key delete confirmation
 	mp.register("/endpoint/{env}/{service}/rest/api/v1/keys/{key}", http.MethodGet, mp.getKMSKeyByID)
+	mp.register("/endpoint/{env}/{service}/rest/api/v1/keys/{key}", http.MethodPatch, mp.patchKMSKeyByID)
 	mp.register("/endpoint/{env}/{service}/rest/api/v1/keys/{key}", http.MethodDelete, mp.deleteKMSKeyByID)
 
 	// See cms_build.go

--- a/kaleido/platform/mockserver_test.go
+++ b/kaleido/platform/mockserver_test.go
@@ -46,6 +46,7 @@ type mockPlatform struct {
 	kmsWallets                  map[string]*KMSWalletAPIModel
 	arsNamespaces               map[string]*ARSNamespaceAPIModel
 	kmsKeys                     map[string]*KMSKeyAPIModel
+	kmsKeysByID                 map[string]*KMSKeyAPIModel // env/service/id for global /keys/{id}
 	cmsBuilds                   map[string]*CMSBuildAPIModel
 	cmsActions                  map[string]CMSActionAPIBaseAccessor
 	amsTasks                    map[string]*AMSTaskAPIModel
@@ -98,6 +99,7 @@ func startMockPlatformServer(t *testing.T) *mockPlatform {
 		kmsWallets:                  make(map[string]*KMSWalletAPIModel),
 		arsNamespaces:               make(map[string]*ARSNamespaceAPIModel),
 		kmsKeys:                     make(map[string]*KMSKeyAPIModel),
+		kmsKeysByID:                 make(map[string]*KMSKeyAPIModel),
 		cmsBuilds:                   make(map[string]*CMSBuildAPIModel),
 		cmsActions:                  make(map[string]CMSActionAPIBaseAccessor),
 		amsTasks:                    make(map[string]*AMSTaskAPIModel),
@@ -187,6 +189,9 @@ func startMockPlatformServer(t *testing.T) *mockPlatform {
 	mp.register("/endpoint/{env}/{service}/rest/api/v1/wallets/{wallet}/keys/{key}", http.MethodGet, mp.getKMSKey)
 	mp.register("/endpoint/{env}/{service}/rest/api/v1/wallets/{wallet}/keys/{key}", http.MethodPatch, mp.patchKMSKey)
 	mp.register("/endpoint/{env}/{service}/rest/api/v1/wallets/{wallet}/keys/{key}", http.MethodDelete, mp.deleteKMSKey)
+	// Global by-ID routes used for folder-key delete confirmation
+	mp.register("/endpoint/{env}/{service}/rest/api/v1/keys/{key}", http.MethodGet, mp.getKMSKeyByID)
+	mp.register("/endpoint/{env}/{service}/rest/api/v1/keys/{key}", http.MethodDelete, mp.deleteKMSKeyByID)
 
 	// See cms_build.go
 	mp.register("/endpoint/{env}/{service}/rest/api/v1/builds", http.MethodPost, mp.postCMSBuild)


### PR DESCRIPTION
This ensures KMS keys and folders are not easily deleted when updates to immutable fields are applied. The user should intentionally delete and recreate the key with their field changes when necessary. 

This PR also includes support for deletion of KMS keys within the KMS folder resource 