### PR TITLE
Support JSON in notificationMethod values

### DIFF
--- a/docs/resources/platform_pms_identity.md
+++ b/docs/resources/platform_pms_identity.md
@@ -59,4 +59,4 @@ Optional:
 
 - `name` (String) Name of the notification method
 - `type` (String) Type of the notification method
-- `value` (String) The type-specific configuration of the notification method, as a JSON string (use jsonencode); the provider sends it to the API as a JSON object
+- `value_json` (String) The type-specific configuration of the notification method, as a JSON string (use jsonencode)

--- a/docs/resources/platform_pms_identity.md
+++ b/docs/resources/platform_pms_identity.md
@@ -59,4 +59,4 @@ Optional:
 
 - `name` (String) Name of the notification method
 - `type` (String) Type of the notification method
-- `value` (String) Value of the notification method as JSON string
+- `value` (String) The type-specific configuration of the notification method, as a JSON string (use jsonencode); the provider sends it to the API as a JSON object

--- a/kaleido/platform/pms_identity.go
+++ b/kaleido/platform/pms_identity.go
@@ -445,14 +445,14 @@ func (r *policyIdentityResource) toData(api *PolicyIdentityAPIModel, data *Polic
 	if len(api.NotificationMethod) > 0 {
 		notificationMethods := make([]attr.Value, len(api.NotificationMethod))
 		for i, nm := range api.NotificationMethod {
-			var jsonValue string
+			valueJSON := types.StringNull()
 			if nm.Value != nil {
-				jsonValue = string(nm.Value)
+				valueJSON = types.StringValue(string(nm.Value))
 			}
 			attrs := map[string]attr.Value{
 				"name":       types.StringValue(nm.Name),
 				"type":       types.StringValue(nm.Type),
-				"value_json": types.StringValue(jsonValue),
+				"value_json": valueJSON,
 			}
 
 			obj, _ := types.ObjectValue(map[string]attr.Type{

--- a/kaleido/platform/pms_identity.go
+++ b/kaleido/platform/pms_identity.go
@@ -17,7 +17,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"reflect"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
@@ -67,12 +66,9 @@ type AssertionMethod struct {
 }
 
 type NotificationMethod struct {
-	Name string `json:"name,omitempty"`
-	Type string `json:"type,omitempty"`
-	// The API models the type-specific notification configuration as an object, so the
-	// JSON string held in the `value` attribute is parsed on the way out and re-rendered
-	// on the way back in - the same treatment `eventSource` gets in kaleido_platform_wfe_stream
-	Value map[string]interface{} `json:"value,omitempty"`
+	Name  string          `json:"name,omitempty"`
+	Type  string          `json:"type,omitempty"`
+	Value json.RawMessage `json:"value,omitempty"` // we don't model the value, just translate it to/from JSON
 }
 
 func PMSIdentityResourceFactory() resource.Resource {
@@ -190,9 +186,9 @@ func (r *policyIdentityResource) Schema(_ context.Context, _ resource.SchemaRequ
 							Description:   "Type of the notification method",
 							PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 						},
-						"value": &schema.StringAttribute{
+						"value_json": &schema.StringAttribute{
 							Optional:      true,
-							Description:   "The type-specific configuration of the notification method, as a JSON string (use jsonencode); the provider sends it to the API as a JSON object",
+							Description:   "The type-specific configuration of the notification method, as a JSON string (use jsonencode)",
 							PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 						},
 					},
@@ -334,13 +330,10 @@ func (r *policyIdentityResource) toAPI(data *PolicyIdentityResourceModel, api *P
 				if val, ok := attrs["type"]; ok && !val.IsNull() {
 					nm.Type = val.(types.String).ValueString()
 				}
-				if val, ok := attrs["value"]; ok && !val.IsNull() {
+				if val, ok := attrs["value_json"]; ok && !val.IsNull() {
 					valueJSON := val.(types.String).ValueString()
 					if valueJSON != "" {
-						if err := json.Unmarshal([]byte(valueJSON), &nm.Value); err != nil {
-							diagnostics.AddError("Invalid JSON", fmt.Sprintf("Failed to parse notification method value JSON: %v", err))
-							return
-						}
+						nm.Value = json.RawMessage(valueJSON)
 					}
 				}
 				notificationMethods = append(notificationMethods, nm)
@@ -348,63 +341,6 @@ func (r *policyIdentityResource) toAPI(data *PolicyIdentityResourceModel, api *P
 		}
 		api.NotificationMethod = notificationMethods
 	}
-}
-
-// priorNotificationMethodValues returns the `value` JSON strings already held in the plan
-// or state, indexed by position in the list, so that a value the API has not actually
-// changed can be echoed back exactly as it was defined
-func priorNotificationMethodValues(data *PolicyIdentityResourceModel) []types.String {
-	if data.NotificationMethod.IsNull() || data.NotificationMethod.IsUnknown() {
-		return nil
-	}
-	elements := data.NotificationMethod.Elements()
-	values := make([]types.String, len(elements))
-	for i, item := range elements {
-		obj, ok := item.(types.Object)
-		if !ok {
-			continue
-		}
-		if val, ok := obj.Attributes()["value"]; ok {
-			if str, ok := val.(types.String); ok {
-				values[i] = str
-			}
-		}
-	}
-	return values
-}
-
-// notificationMethodValueToData renders the object the API returned back into the JSON
-// string held by the `value` attribute. The prior value is kept whenever it describes the
-// same object, because re-marshalling reorders keys and drops whitespace - which would
-// otherwise show up as a permanent diff, or as "Provider produced inconsistent result
-// after apply" for a configuration that did not happen to be written in canonical form.
-func notificationMethodValueToData(apiValue map[string]interface{}, prior types.String) (types.String, error) {
-	if !prior.IsNull() && !prior.IsUnknown() && jsonObjectEquivalent(prior.ValueString(), apiValue) {
-		return prior, nil
-	}
-	if len(apiValue) == 0 {
-		return types.StringNull(), nil
-	}
-	valueBytes, err := json.Marshal(apiValue)
-	if err != nil {
-		return types.StringNull(), err
-	}
-	return types.StringValue(string(valueBytes)), nil
-}
-
-// jsonObjectEquivalent reports whether a JSON string describes the same object as the one
-// the API returned, treating an absent object and an empty one as the same thing
-func jsonObjectEquivalent(priorJSON string, apiValue map[string]interface{}) bool {
-	var priorValue map[string]interface{}
-	if priorJSON != "" {
-		if err := json.Unmarshal([]byte(priorJSON), &priorValue); err != nil {
-			return false
-		}
-	}
-	if len(priorValue) == 0 && len(apiValue) == 0 {
-		return true
-	}
-	return reflect.DeepEqual(priorValue, apiValue)
 }
 
 func (r *policyIdentityResource) toData(api *PolicyIdentityAPIModel, data *PolicyIdentityResourceModel, diagnostics *diag.Diagnostics) {
@@ -505,47 +441,41 @@ func (r *policyIdentityResource) toData(api *PolicyIdentityAPIModel, data *Polic
 		})
 	}
 
-	// Convert notification methods
+	// Convert notification methods from API
 	if len(api.NotificationMethod) > 0 {
-		priorValues := priorNotificationMethodValues(data)
-		var notificationMethods []attr.Value
+		notificationMethods := make([]attr.Value, len(api.NotificationMethod))
 		for i, nm := range api.NotificationMethod {
-			var prior types.String
-			if i < len(priorValues) {
-				prior = priorValues[i]
-			}
-			value, err := notificationMethodValueToData(nm.Value, prior)
-			if err != nil {
-				diagnostics.AddError("JSON Marshal Error", fmt.Sprintf("Failed to marshal notification method value: %v", err))
-				return
+			var jsonValue string
+			if nm.Value != nil {
+				jsonValue = string(nm.Value)
 			}
 			attrs := map[string]attr.Value{
-				"name":  types.StringValue(nm.Name),
-				"type":  types.StringValue(nm.Type),
-				"value": value,
+				"name":       types.StringValue(nm.Name),
+				"type":       types.StringValue(nm.Type),
+				"value_json": types.StringValue(jsonValue),
 			}
 
 			obj, _ := types.ObjectValue(map[string]attr.Type{
-				"name":  types.StringType,
-				"type":  types.StringType,
-				"value": types.StringType,
+				"name":       types.StringType,
+				"type":       types.StringType,
+				"value_json": types.StringType,
 			}, attrs)
 
-			notificationMethods = append(notificationMethods, obj)
+			notificationMethods[i] = obj
 		}
 		data.NotificationMethod = types.ListValueMust(types.ObjectType{
 			AttrTypes: map[string]attr.Type{
-				"name":  types.StringType,
-				"type":  types.StringType,
-				"value": types.StringType,
+				"name":       types.StringType,
+				"type":       types.StringType,
+				"value_json": types.StringType,
 			},
 		}, notificationMethods)
 	} else {
 		data.NotificationMethod = types.ListNull(types.ObjectType{
 			AttrTypes: map[string]attr.Type{
-				"name":  types.StringType,
-				"type":  types.StringType,
-				"value": types.StringType,
+				"name":       types.StringType,
+				"type":       types.StringType,
+				"value_json": types.StringType,
 			},
 		})
 	}

--- a/kaleido/platform/pms_identity.go
+++ b/kaleido/platform/pms_identity.go
@@ -15,10 +15,13 @@ package platform
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"reflect"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
@@ -64,9 +67,12 @@ type AssertionMethod struct {
 }
 
 type NotificationMethod struct {
-	Name  string `json:"name,omitempty"`
-	Type  string `json:"type,omitempty"`
-	Value string `json:"value,omitempty"`
+	Name string `json:"name,omitempty"`
+	Type string `json:"type,omitempty"`
+	// The API models the type-specific notification configuration as an object, so the
+	// JSON string held in the `value` attribute is parsed on the way out and re-rendered
+	// on the way back in - the same treatment `eventSource` gets in kaleido_platform_wfe_stream
+	Value map[string]interface{} `json:"value,omitempty"`
 }
 
 func PMSIdentityResourceFactory() resource.Resource {
@@ -186,7 +192,7 @@ func (r *policyIdentityResource) Schema(_ context.Context, _ resource.SchemaRequ
 						},
 						"value": &schema.StringAttribute{
 							Optional:      true,
-							Description:   "Value of the notification method as JSON string",
+							Description:   "The type-specific configuration of the notification method, as a JSON string (use jsonencode); the provider sends it to the API as a JSON object",
 							PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 						},
 					},
@@ -219,13 +225,19 @@ func (r *policyIdentityResource) Create(ctx context.Context, req resource.Create
 	}
 
 	var api PolicyIdentityAPIModel
-	r.toAPI(&data, &api)
+	r.toAPI(&data, &api, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 	ok, _ := r.apiRequest(ctx, "POST", r.apiPath(&data), api, &api, &resp.Diagnostics)
 	if !ok {
 		return
 	}
 
-	r.toData(&api, &data)
+	r.toData(&api, &data, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 
 	diags = resp.State.Set(ctx, &data)
 	resp.Diagnostics.Append(diags...)
@@ -245,7 +257,10 @@ func (r *policyIdentityResource) Read(ctx context.Context, req resource.ReadRequ
 		return
 	}
 
-	r.toData(&api, &data)
+	r.toData(&api, &data, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 
 	diags = resp.State.Set(ctx, &data)
 	resp.Diagnostics.Append(diags...)
@@ -267,7 +282,7 @@ func (r *policyIdentityResource) Delete(ctx context.Context, req resource.Delete
 	_, _ = r.apiRequest(ctx, "DELETE", r.apiPath(&data), nil, nil, &resp.Diagnostics)
 }
 
-func (r *policyIdentityResource) toAPI(data *PolicyIdentityResourceModel, api *PolicyIdentityAPIModel) {
+func (r *policyIdentityResource) toAPI(data *PolicyIdentityResourceModel, api *PolicyIdentityAPIModel, diagnostics *diag.Diagnostics) {
 	api.Name = data.Name.ValueString()
 	api.Description = data.Description.ValueString()
 	api.Owner = data.Owner.ValueString()
@@ -320,7 +335,13 @@ func (r *policyIdentityResource) toAPI(data *PolicyIdentityResourceModel, api *P
 					nm.Type = val.(types.String).ValueString()
 				}
 				if val, ok := attrs["value"]; ok && !val.IsNull() {
-					nm.Value = val.(types.String).ValueString()
+					valueJSON := val.(types.String).ValueString()
+					if valueJSON != "" {
+						if err := json.Unmarshal([]byte(valueJSON), &nm.Value); err != nil {
+							diagnostics.AddError("Invalid JSON", fmt.Sprintf("Failed to parse notification method value JSON: %v", err))
+							return
+						}
+					}
 				}
 				notificationMethods = append(notificationMethods, nm)
 			}
@@ -329,7 +350,64 @@ func (r *policyIdentityResource) toAPI(data *PolicyIdentityResourceModel, api *P
 	}
 }
 
-func (r *policyIdentityResource) toData(api *PolicyIdentityAPIModel, data *PolicyIdentityResourceModel) {
+// priorNotificationMethodValues returns the `value` JSON strings already held in the plan
+// or state, indexed by position in the list, so that a value the API has not actually
+// changed can be echoed back exactly as it was defined
+func priorNotificationMethodValues(data *PolicyIdentityResourceModel) []types.String {
+	if data.NotificationMethod.IsNull() || data.NotificationMethod.IsUnknown() {
+		return nil
+	}
+	elements := data.NotificationMethod.Elements()
+	values := make([]types.String, len(elements))
+	for i, item := range elements {
+		obj, ok := item.(types.Object)
+		if !ok {
+			continue
+		}
+		if val, ok := obj.Attributes()["value"]; ok {
+			if str, ok := val.(types.String); ok {
+				values[i] = str
+			}
+		}
+	}
+	return values
+}
+
+// notificationMethodValueToData renders the object the API returned back into the JSON
+// string held by the `value` attribute. The prior value is kept whenever it describes the
+// same object, because re-marshalling reorders keys and drops whitespace - which would
+// otherwise show up as a permanent diff, or as "Provider produced inconsistent result
+// after apply" for a configuration that did not happen to be written in canonical form.
+func notificationMethodValueToData(apiValue map[string]interface{}, prior types.String) (types.String, error) {
+	if !prior.IsNull() && !prior.IsUnknown() && jsonObjectEquivalent(prior.ValueString(), apiValue) {
+		return prior, nil
+	}
+	if len(apiValue) == 0 {
+		return types.StringNull(), nil
+	}
+	valueBytes, err := json.Marshal(apiValue)
+	if err != nil {
+		return types.StringNull(), err
+	}
+	return types.StringValue(string(valueBytes)), nil
+}
+
+// jsonObjectEquivalent reports whether a JSON string describes the same object as the one
+// the API returned, treating an absent object and an empty one as the same thing
+func jsonObjectEquivalent(priorJSON string, apiValue map[string]interface{}) bool {
+	var priorValue map[string]interface{}
+	if priorJSON != "" {
+		if err := json.Unmarshal([]byte(priorJSON), &priorValue); err != nil {
+			return false
+		}
+	}
+	if len(priorValue) == 0 && len(apiValue) == 0 {
+		return true
+	}
+	return reflect.DeepEqual(priorValue, apiValue)
+}
+
+func (r *policyIdentityResource) toData(api *PolicyIdentityAPIModel, data *PolicyIdentityResourceModel, diagnostics *diag.Diagnostics) {
 	data.ID = types.StringValue(api.ID)
 	data.Name = types.StringValue(api.Name)
 	// Note: environment and service are not returned by the API, they remain as set in the resource
@@ -429,12 +507,22 @@ func (r *policyIdentityResource) toData(api *PolicyIdentityAPIModel, data *Polic
 
 	// Convert notification methods
 	if len(api.NotificationMethod) > 0 {
+		priorValues := priorNotificationMethodValues(data)
 		var notificationMethods []attr.Value
-		for _, nm := range api.NotificationMethod {
+		for i, nm := range api.NotificationMethod {
+			var prior types.String
+			if i < len(priorValues) {
+				prior = priorValues[i]
+			}
+			value, err := notificationMethodValueToData(nm.Value, prior)
+			if err != nil {
+				diagnostics.AddError("JSON Marshal Error", fmt.Sprintf("Failed to marshal notification method value: %v", err))
+				return
+			}
 			attrs := map[string]attr.Value{
 				"name":  types.StringValue(nm.Name),
 				"type":  types.StringValue(nm.Type),
-				"value": types.StringValue(nm.Value),
+				"value": value,
 			}
 
 			obj, _ := types.ObjectValue(map[string]attr.Type{

--- a/kaleido/platform/pms_identity_test.go
+++ b/kaleido/platform/pms_identity_test.go
@@ -14,6 +14,7 @@
 package platform
 
 import (
+	"encoding/json"
 	"net/http"
 	"testing"
 	"time"
@@ -21,6 +22,7 @@ import (
 	"github.com/aidarkhanov/nanoid"
 	"github.com/gorilla/mux"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/stretchr/testify/assert"
 
 	_ "embed"
@@ -91,9 +93,93 @@ func TestPMSIdentity1(t *testing.T) {
 	})
 }
 
+var pms_identity_notification_value = `
+resource "kaleido_platform_pms_identity" "notify_identity" {
+  environment = "test-env"
+  service = "test-service"
+  name = "notify-identity"
+  notification_method = [
+    {
+      name = "notify-workflow"
+      type = "workflow"
+      value = jsonencode({
+        workflow  = "test-workflow"
+        operation = "test-operation"
+      })
+    }
+  ]
+}
+`
+
+func TestPMSIdentityNotificationMethodValue(t *testing.T) {
+	mp, providerConfig := testSetup(t)
+	defer func() {
+		mp.checkClearCalls([]string{
+			"POST /endpoint/{env}/{service}/rest/api/v1/identities",
+			"GET /endpoint/{env}/{service}/rest/api/v1/identities/{identity}",
+			"GET /endpoint/{env}/{service}/rest/api/v1/identities/{identity}",
+			"DELETE /endpoint/{env}/{service}/rest/api/v1/identities/{identity}",
+		})
+		mp.server.Close()
+	}()
+
+	pms_identity_resource := "kaleido_platform_pms_identity.notify_identity"
+	resource.Test(t, resource.TestCase{
+		IsUnitTest:               true,
+		ProtoV6ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: providerConfig + pms_identity_notification_value,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(pms_identity_resource, "notification_method.0.name", "notify-workflow"),
+					resource.TestCheckResourceAttr(pms_identity_resource, "notification_method.0.type", "workflow"),
+					func(s *terraform.State) error {
+						// The value must have been stored server-side as a structured object,
+						// not as a string containing JSON
+						id := s.RootModule().Resources[pms_identity_resource].Primary.Attributes["id"]
+						obj := mp.policyIdentities[id]
+						assert.Len(t, obj.NotificationMethod, 1)
+						assert.Equal(t, map[string]interface{}{
+							"workflow":  "test-workflow",
+							"operation": "test-operation",
+						}, obj.NotificationMethod[0].Value)
+						return nil
+					},
+				),
+			},
+			{
+				// Re-planning against the value the API returns must produce no diff
+				Config:             providerConfig + pms_identity_notification_value,
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
+// assertNotificationMethodValuesAreObjects fails the test if a notification method value
+// reaches the API as a JSON string rather than as a JSON object
+func (mp *mockPlatform) assertNotificationMethodValuesAreObjects(rawBody []byte) {
+	var wire struct {
+		NotificationMethod []struct {
+			Value json.RawMessage `json:"value"`
+		} `json:"notificationMethod"`
+	}
+	err := json.Unmarshal(rawBody, &wire)
+	assert.NoError(mp.t, err)
+	for _, nm := range wire.NotificationMethod {
+		if len(nm.Value) == 0 {
+			continue
+		}
+		assert.Equal(mp.t, uint8('{'), nm.Value[0],
+			"notificationMethod value must be sent as a JSON object, got: %s", nm.Value)
+	}
+}
+
 func (mp *mockPlatform) postPolicyIdentity(res http.ResponseWriter, req *http.Request) {
 	var obj PolicyIdentityAPIModel
-	mp.getBody(req, &obj)
+	rawBody := mp.peekBody(req, &obj)
+	mp.assertNotificationMethodValuesAreObjects(rawBody)
 	obj.ID = nanoid.New()
 	now := time.Now().UTC()
 	obj.Created = &now

--- a/kaleido/platform/pms_identity_test.go
+++ b/kaleido/platform/pms_identity_test.go
@@ -102,7 +102,7 @@ resource "kaleido_platform_pms_identity" "notify_identity" {
     {
       name = "notify-workflow"
       type = "workflow"
-      value = jsonencode({
+      value_json = jsonencode({
         workflow  = "test-workflow"
         operation = "test-operation"
       })
@@ -139,10 +139,10 @@ func TestPMSIdentityNotificationMethodValue(t *testing.T) {
 						id := s.RootModule().Resources[pms_identity_resource].Primary.Attributes["id"]
 						obj := mp.policyIdentities[id]
 						assert.Len(t, obj.NotificationMethod, 1)
-						assert.Equal(t, map[string]interface{}{
+						assert.JSONEq(t, `{
 							"workflow":  "test-workflow",
-							"operation": "test-operation",
-						}, obj.NotificationMethod[0].Value)
+							"operation": "test-operation"
+						}`, string(obj.NotificationMethod[0].Value))
 						return nil
 					},
 				),

--- a/kaleido/platform/pms_identity_test.go
+++ b/kaleido/platform/pms_identity_test.go
@@ -48,7 +48,7 @@ resource "kaleido_platform_pms_identity" "test_identity" {
     {
       name = "test-notification-method"
       type = "workflow"
-      value = "{\"workflow\": \"test-workflow\", \"operation\": \"test-operation\"}"
+      value_json = "{\"workflow\":\"test-workflow\",\"operation\":\"test-operation\"}"
     }
   ]
 }
@@ -86,7 +86,7 @@ func TestPMSIdentity1(t *testing.T) {
 					resource.TestCheckResourceAttr(pms_identity_resource, "assertion_method.0.signing_method", "local"),
 					resource.TestCheckResourceAttr(pms_identity_resource, "notification_method.0.name", "test-notification-method"),
 					resource.TestCheckResourceAttr(pms_identity_resource, "notification_method.0.type", "workflow"),
-					resource.TestCheckResourceAttr(pms_identity_resource, "notification_method.0.value", "{\"workflow\": \"test-workflow\", \"operation\": \"test-operation\"}"),
+					resource.TestCheckResourceAttr(pms_identity_resource, "notification_method.0.value_json", "{\"workflow\":\"test-workflow\",\"operation\":\"test-operation\"}"),
 				),
 			},
 		},


### PR DESCRIPTION
## Problem

The `value` attribute of a `notification_method` is a `string`, and is send to the API as a string.
The API requires each type of notification method we need to pass a different structure of JSON (not a string).

## Proposed solution

Consistent with other areas of the TF provider that do not model full schema of contents, we rename `value` to `value_json` and allow `jsonencode` of the input data by the caller.