### PR TITLE
[util] Build release version and commit into the User-Agent header

### DIFF
--- a/kaleido/kaleidobase/provider.go
+++ b/kaleido/kaleidobase/provider.go
@@ -24,6 +24,7 @@ import (
 
 type kaleidoProvider struct {
 	version     string
+	commit      string
 	resources   []func() resource.Resource
 	datasources []func() datasource.DataSource
 }
@@ -76,7 +77,7 @@ func (p *kaleidoProvider) Configure(ctx context.Context, req provider.ConfigureR
 	var data ProviderModel
 	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
 
-	pd := NewProviderData(ctx, &data)
+	pd := NewProviderData(ctx, &data, p.version, p.commit)
 	resp.DataSourceData = pd
 	resp.ResourceData = pd
 }
@@ -91,9 +92,10 @@ func (p *kaleidoProvider) Resources(_ context.Context) []func() resource.Resourc
 	return p.resources
 }
 
-func New(version string, resources []func() resource.Resource, datasources []func() datasource.DataSource) provider.Provider {
+func New(version, commit string, resources []func() resource.Resource, datasources []func() datasource.DataSource) provider.Provider {
 	return &kaleidoProvider{
 		version:     version,
+		commit:      commit,
 		resources:   resources,
 		datasources: datasources,
 	}

--- a/kaleido/kaleidobase/providerdata.go
+++ b/kaleido/kaleidobase/providerdata.go
@@ -31,7 +31,20 @@ import (
 	kaleido "github.com/kaleido-io/kaleido-sdk-go/kaleido"
 )
 
-const version = "v1.2.0"
+// buildUserAgent constructs the User-Agent header for API diagnostics from the
+// version and commit injected at release time via ldflags (see .goreleaser.yml).
+func buildUserAgent(version, commit, api string) string {
+	if version == "" {
+		version = "dev"
+	}
+	if len(commit) > 8 {
+		commit = commit[:8]
+	}
+	if commit != "" {
+		version = fmt.Sprintf("%s+%s", version, commit)
+	}
+	return fmt.Sprintf("Terraform / %s (%s)", version, api)
+}
 
 type ProviderData struct {
 	BaaS     *kaleido.KaleidoClient
@@ -66,7 +79,7 @@ func ConfigureProviderData(providerData any, diagnostics *diag.Diagnostics) *Pro
 	return kaleidoProviderData
 }
 
-func NewProviderData(logCtx context.Context, conf *ProviderModel) *ProviderData {
+func NewProviderData(logCtx context.Context, conf *ProviderModel, version, commit string) *ProviderData {
 
 	baasAPI := conf.API.ValueString()
 	if baasAPI == "" {
@@ -80,7 +93,7 @@ func NewProviderData(logCtx context.Context, conf *ProviderModel) *ProviderData 
 		SetTransport(http.DefaultTransport).
 		SetBaseURL(baasAPI).
 		SetAuthToken(baasAPIKey).
-		SetHeader("User-Agent", fmt.Sprintf("Terraform / %s (BaaS)", version))
+		SetHeader("User-Agent", buildUserAgent(version, commit, "BaaS"))
 	AddRestyLogging(logCtx, r)
 	baas := &kaleido.KaleidoClient{Client: r}
 
@@ -115,7 +128,7 @@ func NewProviderData(logCtx context.Context, conf *ProviderModel) *ProviderData 
 	}
 	platform := resty.New().
 		SetTransport(platformHttp).
-		SetHeader("User-Agent", fmt.Sprintf("Terraform / %s (Platform)", version)).
+		SetHeader("User-Agent", buildUserAgent(version, commit, "Platform")).
 		AddRetryCondition(func(r *resty.Response, err error) bool {
 			if err != nil {
 				return false

--- a/kaleido/kaleidobase/providerdata_test.go
+++ b/kaleido/kaleidobase/providerdata_test.go
@@ -1,0 +1,38 @@
+// Copyright © Kaleido, Inc. 2018, 2026
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package kaleidobase
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBuildUserAgent(t *testing.T) {
+	// Release build: goreleaser injects version and full commit hash
+	assert.Equal(t, "Terraform / 1.3.2+abcdef01 (Platform)",
+		buildUserAgent("1.3.2", "abcdef0123456789abcdef0123456789abcdef01", "Platform"))
+
+	// Short commit is used as-is
+	assert.Equal(t, "Terraform / 1.3.2+abc123 (BaaS)",
+		buildUserAgent("1.3.2", "abc123", "BaaS"))
+
+	// Local build: no ldflags at all
+	assert.Equal(t, "Terraform / dev (Platform)",
+		buildUserAgent("", "", "Platform"))
+
+	// Version set but no commit
+	assert.Equal(t, "Terraform / dev (Platform)",
+		buildUserAgent("dev", "", "Platform"))
+}

--- a/kaleido/platform/common_test.go
+++ b/kaleido/platform/common_test.go
@@ -41,6 +41,7 @@ provider "kaleido" {
 func init() {
 	kaleidoProvider := kaleidobase.New(
 		"0.0.1-unittest",
+		"",
 		Resources(),
 		DataSources(),
 	)

--- a/kaleido/provider.go
+++ b/kaleido/provider.go
@@ -40,13 +40,14 @@ func (d *baasBaseDatasource) Configure(_ context.Context, req datasource.Configu
 }
 
 func newTestProviderData() *kaleidobase.ProviderData {
-	return kaleidobase.NewProviderData(context.Background(), &kaleidobase.ProviderModel{})
+	return kaleidobase.NewProviderData(context.Background(), &kaleidobase.ProviderModel{}, "dev", "")
 }
 
-func New(version string) func() provider.Provider {
+func New(version, commit string) func() provider.Provider {
 	return func() provider.Provider {
 		return kaleidobase.New(
 			version,
+			commit,
 			append([]func() resource.Resource{
 				ResourceConsortiumFactory,
 				ResourceEnvironmentFactory,

--- a/kaleido/provider_test.go
+++ b/kaleido/provider_test.go
@@ -25,7 +25,7 @@ var testAccProviders map[string]func() (tfprotov6.ProviderServer, error)
 
 func init() {
 	testAccProviders = map[string]func() (tfprotov6.ProviderServer, error){
-		"kaleido": providerserver.NewProtocol6WithError(New("0.0.1-unittest")()),
+		"kaleido": providerserver.NewProtocol6WithError(New("0.0.1-unittest", "")()),
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -23,8 +23,9 @@ import (
 )
 
 var (
-	// TODO: To be overwritten by a release process
+	// Overwritten at release time by goreleaser via ldflags (see .goreleaser.yml)
 	version string = "dev"
+	commit  string = ""
 )
 
 func main() {
@@ -34,7 +35,7 @@ func main() {
 		//Debug:           true,
 	}
 
-	err := providerserver.Serve(context.Background(), kaleido.New(version), opts)
+	err := providerserver.Serve(context.Background(), kaleido.New(version, commit), opts)
 
 	if err != nil {
 		log.Fatal(err.Error())


### PR DESCRIPTION
## Description

The `User-Agent` header sent to the Kaleido APIs was formatted from a hardcoded `const version = "v1.2.0"` in `kaleidobase/providerdata.go`, added when the header was introduced in #90 and never bumped since. Every release from v1.2.0 through v1.3.2 has identified itself as `Terraform / v1.2.0 (Platform)` in platform access logs, making the header useless for support diagnostics (we hit exactly this while investigating a customer incident: the logs said v1.2.0 and told us nothing about the provider version actually in use).

goreleaser already injects the real values via `-X main.version={{.Version}} -X main.commit={{.Commit}}`, but only `main.version` existed (`main.commit` was a silent no-op since the symbol wasn't declared), and neither value reached the header.

## Changes

- `main.go`: declare `commit`, so the existing goreleaser ldflag actually lands; pass both values into `kaleido.New`.
- Thread `version`/`commit` through `kaleido.New` → `kaleidobase.New` → `NewProviderData`.
- `kaleidobase`: replace the stale const with `buildUserAgent()`, producing e.g. `Terraform / 1.3.2+abcdef01 (Platform)` on release builds (commit truncated to 8 chars, semver build-metadata style) and `Terraform / dev (Platform)` on local builds. The `Terraform / <version> (<api>)` shape is preserved so existing log tooling that greps for it keeps working.

## Testing

- New unit test `TestBuildUserAgent` covering release, short-commit, and local-build shapes.
- `go test ./...` passes (kaleido, kaleidobase, platform suites).
- Verified `go build -ldflags "-X main.version=... -X main.commit=..."` compiles cleanly with the new symbol.